### PR TITLE
feat: 카드 뽑기 UI 부분 구현: 카드 선택, 카드 뒤집기

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import AuthProvider from './utils/AuthProvider';
 import { createGlobalStyle } from 'styled-components';
 import React, { useRef, useEffect, useState } from 'react';
 import SpreadTestPage from './Pages/SpreadTestPage';
+import DrawTestPage from './Pages/DrawTestPage';
 
 const AppContainer = styled.div`
   max-width: 480px;
@@ -68,6 +69,7 @@ function App() {
                 <Route path="/result" element={<ResultPage />} />
                 <Route path="/login/:platform" element={<LoginPage />} />
                 <Route path="/spread-test" element={<SpreadTestPage />} />
+                <Route path="/draw-test" element={<DrawTestPage />} />
               </Routes>
             </Router>
           </AppContainer>

--- a/src/Components/SpreadDisplay.tsx
+++ b/src/Components/SpreadDisplay.tsx
@@ -1,27 +1,65 @@
+import { useState } from 'react';
+import styled from 'styled-components';
 import { DrawnTarotCard } from '../Types/tarotCard';
 import {
   SingleSpread,
   TripleSpread,
-  FiveCardSpread,
+  FiveCardCross,
   CelticCrossSpread
 } from './Spreads';
+
+const SpreadContainer = styled.div`
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+`;
 
 interface SpreadDisplayProps {
   cards: DrawnTarotCard[];
   revealed?: boolean;
+  onAllCardsRevealed?: () => void;
+  visibleCardCount?: number;
 }
 
-export default function SpreadDisplay({ cards, revealed = false }: SpreadDisplayProps) {
-  switch (cards.length) {
-    case 1:
-      return <SingleSpread cards={cards} revealed={revealed} />;
-    case 3:
-      return <TripleSpread cards={cards} revealed={revealed} />;
-    case 5:
-      return <FiveCardSpread cards={cards} revealed={revealed} />;
-    case 10:
-      return <CelticCrossSpread cards={cards} revealed={revealed} />;
-    default:
-      return <div>지원하지 않는 스프레드입니다.</div>;
-  }
+export default function SpreadDisplay({ 
+  cards, 
+  revealed = false,
+  onAllCardsRevealed,
+  visibleCardCount = 0
+}: SpreadDisplayProps) {
+  const [revealedCount, setRevealedCount] = useState(0);
+
+  const handleCardReveal = () => {
+    const newCount = revealedCount + 1;
+    setRevealedCount(newCount);
+    
+    if (newCount === cards.length && onAllCardsRevealed) {
+      onAllCardsRevealed();
+    }
+  };
+
+  const renderSpread = () => {
+    switch (cards.length) {
+      case 1:
+        return <SingleSpread cards={cards} revealed={revealed} onReveal={handleCardReveal} visibleCardCount={visibleCardCount} />;
+      case 3:
+        return <TripleSpread cards={cards} revealed={revealed} onReveal={handleCardReveal} visibleCardCount={visibleCardCount} />;
+      case 5:
+        return <FiveCardCross cards={cards} revealed={revealed} onReveal={handleCardReveal} visibleCardCount={visibleCardCount} />;
+      case 10:
+        return <CelticCrossSpread cards={cards} revealed={revealed} onReveal={handleCardReveal} visibleCardCount={visibleCardCount} />;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <SpreadContainer>
+      {renderSpread()}
+    </SpreadContainer>
+  );
 }

--- a/src/Components/Spreads/CelticCrossSpread.tsx
+++ b/src/Components/Spreads/CelticCrossSpread.tsx
@@ -5,42 +5,101 @@ import { CelticCrossContainer, GridContainer } from './styles/CelticCross.styles
 interface SpreadProps {
   cards: DrawnTarotCard[];
   revealed?: boolean;
+  onReveal?: () => void;
+  visibleCardCount?: number;
 }
 
-export default function CelticCrossSpread({ cards, revealed = false }: SpreadProps) {
+export default function CelticCrossSpread({ 
+  cards, 
+  revealed = false, 
+  onReveal,
+  visibleCardCount = 0 
+}: SpreadProps) {
+  if (cards.length < 10) return null;
+
   return (
     <CelticCrossContainer>
       <GridContainer>
         <div className="overlay-card">
-          <Card card={cards[0]} isRevealed={revealed} />
+          <div style={{ 
+            opacity: visibleCardCount > 1 ? 1 : 0,
+            transition: 'opacity 0.3s ease',
+            pointerEvents: visibleCardCount > 1 ? 'auto' : 'none',
+            height: '100%',
+            zIndex: 2
+          }}>
+            <Card card={cards[1]} isRevealed={revealed} onReveal={onReveal} />
+          </div>
         </div>
+
         <div className="center-cross">
-          <Card card={cards[1]} isRevealed={revealed} />
+          <div style={{ 
+            opacity: visibleCardCount > 0 ? 1 : 0,
+            transition: 'opacity 0.3s ease',
+            pointerEvents: visibleCardCount > 0 ? 'auto' : 'none',
+            height: '100%',
+            zIndex: 1
+          }}>
+            <Card card={cards[0]} isRevealed={revealed} onReveal={onReveal} />
+          </div>
         </div>
+
         <div className="below">
-          <Card card={cards[2]} isRevealed={revealed} />
+          <div style={{ 
+            opacity: visibleCardCount > 2 ? 1 : 0,
+            transition: 'opacity 0.3s ease',
+            pointerEvents: visibleCardCount > 2 ? 'auto' : 'none',
+            height: '100%'
+          }}>
+            <Card card={cards[2]} isRevealed={revealed} onReveal={onReveal} />
+          </div>
         </div>
+
         <div className="left">
-          <Card card={cards[3]} isRevealed={revealed} />
+          <div style={{ 
+            opacity: visibleCardCount > 3 ? 1 : 0,
+            transition: 'opacity 0.3s ease',
+            pointerEvents: visibleCardCount > 3 ? 'auto' : 'none',
+            height: '100%'
+          }}>
+            <Card card={cards[3]} isRevealed={revealed} onReveal={onReveal} />
+          </div>
         </div>
+
         <div className="above">
-          <Card card={cards[4]} isRevealed={revealed} />
+          <div style={{ 
+            opacity: visibleCardCount > 4 ? 1 : 0,
+            transition: 'opacity 0.3s ease',
+            pointerEvents: visibleCardCount > 4 ? 'auto' : 'none',
+            height: '100%'
+          }}>
+            <Card card={cards[4]} isRevealed={revealed} onReveal={onReveal} />
+          </div>
         </div>
+
         <div className="right">
-          <Card card={cards[5]} isRevealed={revealed} />
+          <div style={{ 
+            opacity: visibleCardCount > 5 ? 1 : 0,
+            transition: 'opacity 0.3s ease',
+            pointerEvents: visibleCardCount > 5 ? 'auto' : 'none',
+            height: '100%'
+          }}>
+            <Card card={cards[5]} isRevealed={revealed} onReveal={onReveal} />
+          </div>
         </div>
-        <div className="staff first">
-          <Card card={cards[6]} isRevealed={revealed} />
-        </div>
-        <div className="staff second">
-          <Card card={cards[7]} isRevealed={revealed} />
-        </div>
-        <div className="staff third">
-          <Card card={cards[8]} isRevealed={revealed} />
-        </div>
-        <div className="staff fourth">
-          <Card card={cards[9]} isRevealed={revealed} />
-        </div>
+
+        {['first', 'second', 'third', 'fourth'].map((position, index) => (
+          <div key={index} className={`staff ${position}`}>
+            <div style={{ 
+              opacity: visibleCardCount > (9 - index) ? 1 : 0,
+              transition: 'opacity 0.3s ease',
+              pointerEvents: visibleCardCount > (9 - index) ? 'auto' : 'none',
+              height: '100%'
+            }}>
+              <Card card={cards[9 - index]} isRevealed={revealed} onReveal={onReveal} />
+            </div>
+          </div>
+        ))}
       </GridContainer>
     </CelticCrossContainer>
   );

--- a/src/Components/Spreads/FiveCardCross.tsx
+++ b/src/Components/Spreads/FiveCardCross.tsx
@@ -8,31 +8,75 @@ import {
 interface SpreadProps {
   cards: DrawnTarotCard[];
   revealed?: boolean;
+  onReveal?: () => void;
+  visibleCardCount?: number;
 }
 
-export default function FiveCardCross({ cards, revealed = false }: SpreadProps) {
+export default function FiveCardCross({ 
+  cards, 
+  revealed = false, 
+  onReveal,
+  visibleCardCount = 0 
+}: SpreadProps) {
+  if (cards.length < 5) return null;
+
   return (
     <CrossContainer>
       <GridContainer>
         <div className="empty" />
         <div className="card-slot">
-          <Card card={cards[3]} isRevealed={revealed} />
+          <div style={{ 
+            opacity: visibleCardCount > 4 ? 1 : 0,
+            transition: 'opacity 0.3s ease',
+            pointerEvents: visibleCardCount > 4 ? 'auto' : 'none',
+            height: '100%'
+          }}>
+            <Card card={cards[4]} isRevealed={revealed} onReveal={onReveal} />
+          </div>
         </div>
         <div className="empty" />
         
         <div className="card-slot">
-          <Card card={cards[0]} isRevealed={revealed} />
+          <div style={{ 
+            opacity: visibleCardCount > 1 ? 1 : 0,
+            transition: 'opacity 0.3s ease',
+            pointerEvents: visibleCardCount > 1 ? 'auto' : 'none',
+            height: '100%'
+          }}>
+            <Card card={cards[1]} isRevealed={revealed} onReveal={onReveal} />
+          </div>
         </div>
         <div className="card-slot">
-          <Card card={cards[1]} isRevealed={revealed} />
+          <div style={{ 
+            opacity: visibleCardCount > 0 ? 1 : 0,
+            transition: 'opacity 0.3s ease',
+            pointerEvents: visibleCardCount > 0 ? 'auto' : 'none',
+            height: '100%'
+          }}>
+            <Card card={cards[0]} isRevealed={revealed} onReveal={onReveal} />
+          </div>
         </div>
         <div className="card-slot">
-          <Card card={cards[2]} isRevealed={revealed} />
+          <div style={{ 
+            opacity: visibleCardCount > 2 ? 1 : 0,
+            transition: 'opacity 0.3s ease',
+            pointerEvents: visibleCardCount > 2 ? 'auto' : 'none',
+            height: '100%'
+          }}>
+            <Card card={cards[2]} isRevealed={revealed} onReveal={onReveal} />
+          </div>
         </div>
         
         <div className="empty" />
         <div className="card-slot">
-          <Card card={cards[4]} isRevealed={revealed} />
+          <div style={{ 
+            opacity: visibleCardCount > 3 ? 1 : 0,
+            transition: 'opacity 0.3s ease',
+            pointerEvents: visibleCardCount > 3 ? 'auto' : 'none',
+            height: '100%'
+          }}>
+            <Card card={cards[3]} isRevealed={revealed} onReveal={onReveal} />
+          </div>
         </div>
         <div className="empty" />
       </GridContainer>

--- a/src/Components/Spreads/SingleSpread.tsx
+++ b/src/Components/Spreads/SingleSpread.tsx
@@ -5,12 +5,32 @@ import { SingleSpreadContainer } from './styles/SingleSpread.styles';
 interface SpreadProps {
   cards: DrawnTarotCard[];
   revealed?: boolean;
+  onReveal?: () => void;
+  visibleCardCount?: number;
 }
 
-export default function SingleSpread({ cards, revealed = false }: SpreadProps) {
+export default function SingleSpread({ 
+  cards, 
+  revealed = false, 
+  onReveal,
+  visibleCardCount = 0
+}: SpreadProps) {
+  if (!cards.length) return null;
+  
   return (
     <SingleSpreadContainer>
-      <Card card={cards[0]} isRevealed={revealed} />
+      <div style={{ 
+        opacity: visibleCardCount > 0 ? 1 : 0,
+        transition: 'opacity 0.3s ease',
+        pointerEvents: visibleCardCount > 0 ? 'auto' : 'none',
+        height: '100%'
+      }}>
+        <Card 
+          card={cards[0]} 
+          isRevealed={revealed} 
+          onReveal={onReveal}
+        />
+      </div>
     </SingleSpreadContainer>
   );
 } 

--- a/src/Components/Spreads/TripleSpread.tsx
+++ b/src/Components/Spreads/TripleSpread.tsx
@@ -8,18 +8,34 @@ import {
 interface SpreadProps {
   cards: DrawnTarotCard[];
   revealed?: boolean;
+  onReveal?: () => void;
+  visibleCardCount?: number;
 }
 
-export default function TripleSpread({ cards, revealed = false }: SpreadProps) {
+export default function TripleSpread({ 
+  cards, 
+  revealed = false, 
+  onReveal,
+  visibleCardCount = cards.length 
+}: SpreadProps) {
   return (
     <TripleSpreadContainer>
       <CardsRow>
         {cards.map((card, index) => (
-          <Card 
+          <div 
             key={index}
-            card={card}
-            isRevealed={revealed}
-          />
+            style={{ 
+              opacity: index < visibleCardCount ? 1 : 0,
+              transition: 'opacity 0.3s ease',
+              pointerEvents: index < visibleCardCount ? 'auto' : 'none'
+            }}
+          >
+            <Card 
+              card={card}
+              isRevealed={revealed}
+              onReveal={onReveal}
+            />
+          </div>
         ))}
       </CardsRow>
     </TripleSpreadContainer>

--- a/src/Components/Spreads/index.ts
+++ b/src/Components/Spreads/index.ts
@@ -1,4 +1,4 @@
 export { default as SingleSpread } from './SingleSpread';
 export { default as TripleSpread } from './TripleSpread';
-export { default as FiveCardSpread } from './FiveCardCross';
+export { default as FiveCardCross } from './FiveCardCross';
 export { default as CelticCrossSpread } from './CelticCrossSpread'; 

--- a/src/Components/Spreads/styles/TripleSpread.styles.ts
+++ b/src/Components/Spreads/styles/TripleSpread.styles.ts
@@ -1,19 +1,31 @@
 import styled from 'styled-components';
 
 export const TripleSpreadContainer = styled.div`
+  width: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 100%;
-  min-height: 400px;
   padding: 20px;
 `;
 
 export const CardsRow = styled.div`
-  display: flex;
-  gap: 20px;  // 카드 사이의 간격
-  
-  @media (max-width: 768px) {
-    gap: 10px;  // 모바일에서는 간격을 좁힘
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  width: 100%;
+  max-width: 800px;
+
+  > div {
+    position: relative;
+    padding-top: 140%;
+    width: 100%;
+
+    > * {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+    }
   }
 `; 

--- a/src/Pages/DrawPage.tsx
+++ b/src/Pages/DrawPage.tsx
@@ -1,20 +1,87 @@
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
+import styled from 'styled-components';
 import { DrawnTarotCard } from '../Types/tarotCard';
 import { drawRandomCards } from '../utils/drawRandomCards';
 import { formatUserInputAndCardInfo } from '../utils/formatUserInputAndCardInfo';
 import { callVertexAPI } from '../api/callVertexApi';
+import SpreadDisplay from '../Components/SpreadDisplay';
+
+// 스타일 컴포넌트
+const DrawPageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+  padding: 20px;
+`;
+
+const PhaseButton = styled.button`
+  padding: 12px 24px;
+  border-radius: 8px;
+  border: none;
+  background: #007bff;
+  color: white;
+  cursor: pointer;
+  font-size: 1.1rem;
+
+  &:hover {
+    background: #0056b3;
+  }
+
+  &:disabled {
+    background: #ccc;
+    cursor: not-allowed;
+  }
+`;
+
+const CardsGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(13, 1fr);
+  gap: 8px;
+  width: 100%;
+  max-width: 1200px;
+`;
+
+const CardButton = styled.button<{ $isSelected: boolean }>`
+  aspect-ratio: 1/1.4;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  cursor: pointer;
+  opacity: ${props => props.$isSelected ? 0.5 : 1};
+  
+  &:disabled {
+    cursor: not-allowed;
+  }
+`;
+
+const FlavorText = styled.div<{ $visible: boolean }>`
+  font-size: 1.2rem;
+  color: #2c3e50;
+  text-align: center;
+  opacity: ${props => props.$visible ? 1 : 0};
+  transition: opacity 0.5s ease;
+  margin-top: 16px;
+  font-style: italic;
+`;
+
+type DrawPhase = 'shuffle' | 'cut' | 'draw' | 'reveal';
 
 export default function DrawPage() {
   const location = useLocation();
   const navigate = useNavigate();
   const { userInput, cardCount } = location.state || {};
 
+  const [currentPhase, setCurrentPhase] = useState<DrawPhase>('shuffle');
   const [drawnCards, setDrawnCards] = useState<DrawnTarotCard[]>([]);
-  const [isAnimating, setIsAnimating] = useState(true);
+  const [selectedCardIndices, setSelectedCardIndices] = useState<number[]>([]);
   const [apiResponse, setApiResponse] = useState<string | null>(null);
+  const [showFlavorText, setShowFlavorText] = useState(false);
+  const [readyToNavigate, setReadyToNavigate] = useState(false);
   const hasFetched = useRef(false);
+  const [cardsRevealed, setCardsRevealed] = useState(false);
 
+  // API 요청 및 카드 뽑기 초기화
   useEffect(() => {
     if (!userInput || !cardCount) {
       navigate('/');
@@ -28,10 +95,7 @@ export default function DrawPage() {
 
       (async () => {
         try {
-          const formattedQuery = formatUserInputAndCardInfo(
-            userInput,
-            drawnCardsResult
-          );
+          const formattedQuery = formatUserInputAndCardInfo(userInput, drawnCardsResult);
           const fetchedApiResponse = await callVertexAPI(formattedQuery);
           const responseText = fetchedApiResponse.content?.[0]?.text || '';
           setApiResponse(responseText);
@@ -40,32 +104,90 @@ export default function DrawPage() {
           setApiResponse('API 요청에 실패했습니다.');
         }
       })();
-      
     }
   }, [userInput, cardCount, navigate]);
 
-  const handleButtonClick = () => {
-    setIsAnimating(false);
+  // 페이즈 전환 핸들러
+  const handlePhaseChange = (phase: DrawPhase) => {
+    setCurrentPhase(phase);
   };
-  //TBD: 멋지고 그럴듯한 카드 뽑기 로직과 애니메이션
 
-  useEffect(() => {
-    if (!isAnimating && apiResponse) {
-      navigate('/result', { state: { userInput,apiResponse, drawnCards } });
+  // 카드 선택 핸들러
+  const handleCardSelect = (index: number) => {
+    if (selectedCardIndices.length < cardCount) {
+      setSelectedCardIndices(prev => [...prev, index]);
     }
-  }, [isAnimating, apiResponse, navigate, drawnCards]);
+  };
+
+  // 모든 카드가 공개되었을 때 처리
+  const handleAllCardsRevealed = () => {
+    setShowFlavorText(true);
+    setCardsRevealed(true);
+    setTimeout(() => {
+      setReadyToNavigate(true);
+    }, 1000);
+  };
+
+  // 결과 페이지로 이동
+  useEffect(() => {
+    if (readyToNavigate && apiResponse) {
+      navigate('/result', { state: { userInput, apiResponse, drawnCards } });
+    }
+  }, [readyToNavigate, apiResponse, navigate, userInput, drawnCards]);
 
   return (
-    <div>
-      <h2>카드를 선택해 주세요</h2>
-      {isAnimating ? (
-        <>
-          <p>카드를 섞고 있습니다...</p>
-          <button onClick={handleButtonClick}>카드 선택하기</button>
-        </>
-      ) : (
-        <p>카드가 선택되었습니다. 결과를 해석 중입니다...</p>
+    <DrawPageContainer>
+      {currentPhase === 'shuffle' && (
+        <PhaseButton onClick={() => handlePhaseChange('cut')}>
+          카드 섞기
+        </PhaseButton>
       )}
-    </div>
+
+      {currentPhase === 'cut' && (
+        <PhaseButton onClick={() => handlePhaseChange('draw')}>
+          카드 자르기
+        </PhaseButton>
+      )}
+
+      {currentPhase === 'draw' && (
+        <>
+          <CardsGrid>
+            {Array.from({ length: 78 }, (_, i) => (
+              <CardButton
+                key={i}
+                $isSelected={selectedCardIndices.includes(i)}
+                disabled={selectedCardIndices.includes(i)}
+                onClick={() => handleCardSelect(i)}
+              >
+                {i + 1}
+              </CardButton>
+            ))}
+          </CardsGrid>
+          <SpreadDisplay
+            cards={drawnCards}
+            revealed={cardsRevealed}
+            onAllCardsRevealed={handleAllCardsRevealed}
+            visibleCardCount={selectedCardIndices.length}
+          />
+          <FlavorText $visible={showFlavorText}>
+            이제 타로가 당신의 운명을 보여줄 것입니다...
+          </FlavorText>
+        </>
+      )}
+
+      {currentPhase === 'reveal' && (
+        <>
+          <SpreadDisplay
+            cards={drawnCards}
+            revealed={true}
+            visibleCardCount={cardCount}
+            onAllCardsRevealed={handleAllCardsRevealed}
+          />
+          <FlavorText $visible={showFlavorText}>
+            이제 타로가 당신의 운명을 보여줄 것입니다...
+          </FlavorText>
+        </>
+      )}
+    </DrawPageContainer>
   );
 }

--- a/src/Pages/DrawTestPage.tsx
+++ b/src/Pages/DrawTestPage.tsx
@@ -1,0 +1,138 @@
+import { useState } from 'react';
+import styled from 'styled-components';
+import { DrawnTarotCard } from '../Types/tarotCard';
+import { drawRandomCards } from '../utils/drawRandomCards';
+import SpreadDisplay from '../Components/SpreadDisplay';
+import SpreadSelector from '../Components/SpreadSelector';
+
+const TestPageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+  padding: 20px;
+`;
+
+const StartButton = styled.button`
+  padding: 12px 24px;
+  border: none;
+  border-radius: 8px;
+  background: #007bff;
+  color: white;
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: background 0.2s;
+
+  &:hover {
+    background: #0056b3;
+  }
+`;
+
+const CardsGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(13, 1fr);
+  gap: 8px;
+  width: 100%;
+  max-width: 1200px;
+`;
+
+const CardButton = styled.button<{ $isSelected: boolean }>`
+  aspect-ratio: 1/1.4;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  cursor: pointer;
+  opacity: ${props => props.$isSelected ? 0.5 : 1};
+  
+  &:disabled {
+    cursor: not-allowed;
+  }
+`;
+
+const CardInfo = styled.div`
+  width: 100%;
+  padding: 16px;
+  background: #f8f9fa;
+  border-radius: 8px;
+  margin-bottom: 16px;
+  font-family: monospace;
+  white-space: pre-wrap;
+  word-break: break-all;
+`;
+
+export default function DrawTestPage() {
+  const [cardCount, setCardCount] = useState(1);
+  const [drawnCards, setDrawnCards] = useState<DrawnTarotCard[]>([]);
+  const [selectedCardIndices, setSelectedCardIndices] = useState<number[]>([]);
+  const [isDrawing, setIsDrawing] = useState(false);
+
+  const handleCardCountChange = (newCardCount: number) => {
+    setCardCount(newCardCount);
+    setSelectedCardIndices([]);
+    setIsDrawing(false);
+    const cards = drawRandomCards(newCardCount);
+    setDrawnCards(cards);
+  };
+
+  const handleStartDrawing = () => {
+    setIsDrawing(true);
+  };
+
+  const handleCardSelect = (index: number) => {
+    if (selectedCardIndices.length < cardCount) {
+      setSelectedCardIndices(prev => [...prev, index]);
+    }
+  };
+
+  const handleAllCardsRevealed = () => {
+    console.log('All cards revealed!');
+  };
+
+  return (
+    <TestPageContainer>
+      {drawnCards.length > 0 && (
+        <CardInfo>
+          {drawnCards.map((card, index) => (
+            <div key={index}>
+              {index + 1}번 카드: {card.name.ko} ({card.direction})
+            </div>
+          ))}
+        </CardInfo>
+      )}
+      
+      {!isDrawing ? (
+        <>
+          <SpreadSelector
+            cardCount={cardCount}
+            onCardCountChange={handleCardCountChange}
+          />
+          {drawnCards.length > 0 && (
+            <StartButton onClick={handleStartDrawing}>
+              카드 뽑기 시작
+            </StartButton>
+          )}
+        </>
+      ) : (
+        <>
+          <CardsGrid>
+            {Array.from({ length: 78 }, (_, i) => (
+              <CardButton
+                key={i}
+                $isSelected={selectedCardIndices.includes(i)}
+                disabled={selectedCardIndices.includes(i)}
+                onClick={() => handleCardSelect(i)}
+              >
+                {i + 1}
+              </CardButton>
+            ))}
+          </CardsGrid>
+          <SpreadDisplay
+            cards={drawnCards}
+            revealed={false}
+            onAllCardsRevealed={handleAllCardsRevealed}
+            visibleCardCount={selectedCardIndices.length}
+          />
+        </>
+      )}
+    </TestPageContainer>
+  );
+} 

--- a/src/Pages/ResultPage.tsx
+++ b/src/Pages/ResultPage.tsx
@@ -25,7 +25,11 @@ export default function ResultPage() {
 
       <Section>
         <Title>뽑힌 카드</Title>
-        <SpreadDisplay cards={drawnCards} revealed={true} />
+        <SpreadDisplay 
+          cards={drawnCards} 
+          revealed={true}
+          visibleCardCount={drawnCards.length}
+        />
       </Section>
 
       <Section>

--- a/src/Pages/SpreadTestPage.tsx
+++ b/src/Pages/SpreadTestPage.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { SingleSpread, TripleSpread, FiveCardSpread, CelticCrossSpread } from '../Components/Spreads';
+import { SingleSpread, TripleSpread,FiveCardCross, CelticCrossSpread } from '../Components/Spreads';
 import { drawRandomCards } from '../utils/drawRandomCards';
 
 const TestPageContainer = styled.div`

--- a/src/utils/drawRandomCards.ts
+++ b/src/utils/drawRandomCards.ts
@@ -1,8 +1,8 @@
 import { random, shuffle } from 'es-toolkit';
 import { tarotDeck } from '../data/tarotDeck';
-import { TarotCard } from '../Types/tarotCard';
+import { TarotCard, DrawnTarotCard } from '../Types/tarotCard';
 
-export function drawRandomCards(cardCount: number) {
+export function drawRandomCards(cardCount: number): DrawnTarotCard[] {
   const shuffledDeck = shuffle([...tarotDeck]);
 
   const result = shuffledDeck
@@ -11,11 +11,11 @@ export function drawRandomCards(cardCount: number) {
   return result;
 }
 
-function processCardDirection(card: TarotCard) {
+function processCardDirection(card: TarotCard): DrawnTarotCard {
   const direction: '정방향' | '역방향' =
     random(0, 1) > 0.5 ? '정방향' : '역방향';
 
-  const result = {
+  const result: DrawnTarotCard = {
     id: card.id,
     name: card.name,
     arcanaType: card.arcanaType,


### PR DESCRIPTION
- DrawPage의 UX 진행을 shuffle, cut, draw, reveal의 4개 페이즈로 분할함
  - shuffle: 카드 덱 뭉치를 셔플 (TBD)
  - cut: 카드 덱 뭉치를 3분할하여 순서 섞기 (TBD)
  - draw: 78장의 카드를 펼쳐서 보여주고, 클릭하면 정해진 스프레드에 하나씩 카드가 표시되게 함. 현 단계에선 버튼으로만 구현
  - reveal: 카드를 모두 고른 후, 스프레드에 뒷면으로 표시된 카드를 사용자가 직접 뒤집는 페이즈
  상기한 4개 페이즈를 모두 마치면 ResultPage로 이동하여 해석 결과를 보여줌
- 기존에 결과 페이지에서 뽑은 카드를 보여주는 기능만 가지고 있었던 SpreadDisplay 컴포넌트를 구체화하여 DrawPage에서 사용자가 카드를 직접 뽑는 UX에도 활용할 수 있도록 함

참고사항
- 실제 API 요청 없이 각 스프레드를 테스트할 수 있는 draw-test 페이지를 구현함. 추후에 삭제할 것.
- reveal 페이즈는 필요한 모든 내용이 구현되었으나, draw의 78장 카드 표시, shuffle과 cut의 애니메이션 구현이 필요함
- /draw => /result로 이동 시에 적절한 애니메이션을 보여줄 것
- draw => reveal 페이즈 이동 시에 78장 카드가 사라지는 것도 애니메이션으로 자연스럽게 처리 필요

API 관련
- 실제로 API 요청하며 테스트해보니 켈틱 크로스 스프레드로 요청했을 때 답변이 잘리는 증상이 발생. 스프레드별로 가용 토큰을 조절하는 처리가 필요할 듯 함
- 뽑힌 카드의 순서가 의미에 중요한 영향을 미치는 스프레드의 경우, 해석을 더 디테일하게 다듬을 필요가 있음. 이전에 구상해둔 promptSnippet으로 스프레드별로 각 카드가 상징하는 바와 해석 가이드라인을 모델에 제공해야 할듯
- 추가적으로 '이는 단순히 타로 결과일 뿐이며 참고 용도로만 사용하기 바람'같은 문구를 생성하지 않게 방지하는 프롬프트 조각이 필요
- '안녕하세요, 주어진 카드로 타로 해석을 제공하겠습니다'같은 상투문구도 없애야됨