### PR TITLE
feat: 드로우 페이즈에서 카드를 뽑는 버튼을 애니메이션을 포함한 컴포넌트로 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^1.7.7",
         "es-toolkit": "^1.25.2",
         "firebase": "^11.0.1",
+        "motion": "^11.15.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.27.0",
@@ -884,9 +885,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
-      "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.4.tgz",
+      "integrity": "sha512-zSkKow6H5Kdm0ZUQUB2kV5JIXqoG0+uH5YADhaEHswm664N9Db8dXSi0nMJpacpMf+MyyglF1vnZohpEg5yUtg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2998,9 +2999,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3586,6 +3587,33 @@
         "node": ">= 0.12"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.15.0.tgz",
+      "integrity": "sha512-MLk8IvZntxOMg7lDBLw2qgTHHv664bYoYmnFTmE0Gm/FW67aOJk0WM3ctMcG+Xhcv+vh5uyyXwxvxhSeJzSe+w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.14.3",
+        "motion-utils": "^11.14.3",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4150,6 +4178,44 @@
         "node": "*"
       }
     },
+    "node_modules/motion": {
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-11.15.0.tgz",
+      "integrity": "sha512-iZ7dwADQJWGsqsSkBhNHdI2LyYWU+hA1Nhy357wCLZq1yHxGImgt3l7Yv0HT/WOskcYDq9nxdedyl4zUv7UFFw==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^11.15.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.14.3",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.14.3.tgz",
+      "integrity": "sha512-lW+D2wBy5vxLJi6aCP0xyxTxlTfiu+b+zcpVbGVFUxotwThqhdpPRSmX8xztAgtZMPMeU0WGVn/k1w4I+TbPqA==",
+      "license": "MIT"
+    },
+    "node_modules/motion-utils": {
+      "version": "11.14.3",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.14.3.tgz",
+      "integrity": "sha512-Xg+8xnqIJTpr0L/cidfTTBFkvRw26ZtGGuIhA94J9PQ2p4mEa06Xx7QVYZH0BP+EpMSaDlu+q0I0mmvwADPsaQ==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4157,9 +4223,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "axios": "^1.7.7",
     "es-toolkit": "^1.25.2",
     "firebase": "^11.0.1",
+    "motion": "^11.15.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.27.0",

--- a/src/Components/Card.tsx
+++ b/src/Components/Card.tsx
@@ -17,9 +17,9 @@ interface CardProps {
 export default function Card({ card, isRevealed = false, onReveal }: CardProps) {
   const [isFlipped, setIsFlipped] = useState(isRevealed);
   const isReversed = card.direction === '역방향';
-  
+
   const handleClick = () => {
-    if (!isRevealed && onReveal) {
+    if (!isFlipped && onReveal) {
       onReveal();
     }
     setIsFlipped(true);

--- a/src/Components/DrawPhaseDisplay.tsx
+++ b/src/Components/DrawPhaseDisplay.tsx
@@ -1,0 +1,101 @@
+import styled from 'styled-components';
+import { motion } from 'motion/react';
+
+const DeckContainer = styled.div`
+  width: 100%;
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: -40px;
+  justify-content: center;
+`;
+
+const CardRow = styled.div`
+  position: relative;
+  height: 45%;
+  min-height: 180px;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  overflow: visible;
+`;
+
+const CardBack = styled(motion.button)<{ $index: number }>`
+  position: absolute;
+  width: 25%;
+  min-width: 90px;
+  height: 42.9%;
+  min-height: 154px;
+  border-radius: 7px;
+  cursor: pointer;
+  border: none;
+  background: url('/cards/default/back.webp') no-repeat center center;
+  background-size: cover;
+  left: ${props => `calc(50% - (26 * 3% + 25%) / 2 + ${props.$index} * 3%)`};
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+`;
+
+interface DrawPhaseDisplayProps {
+  onCardSelect: (index: number) => void;
+  selectedIndices: number[];
+}
+
+export default function DrawPhaseDisplay({ onCardSelect, selectedIndices }: DrawPhaseDisplayProps) {
+  const rows = Array.from({ length: 3 }, (_, rowIndex) => {
+    const startIndex = rowIndex * 26;
+
+    return (
+      <CardRow key={rowIndex}>
+        {Array.from({ length: 26 }, (_, i) => {
+          const cardIndex = startIndex + i;
+          if (cardIndex >= 78) return null;
+          
+          return (
+            <CardBack
+              key={cardIndex}
+              $index={i}
+              disabled={selectedIndices.includes(cardIndex)}
+              onClick={() => onCardSelect(cardIndex)}
+              variants={{
+                hidden: {
+                  opacity: 0,
+                  x: 100
+                },
+                visible: {
+                  opacity: 1,
+                  x: 0,
+                  transition: {
+                    duration: 0.3,
+                    delay: cardIndex * 0.02,
+                    ease: "easeOut"
+                  }
+                },
+                selected: {
+                  x: 0,
+                  y: 200,
+                  opacity: 0,
+                  transition: {
+                    y: { duration: 0.8, ease: "easeIn" },
+                    opacity: { duration: 0.4 }
+                  }
+                },
+                unselected: {
+                  x: 0,
+                  y: 0,
+                  opacity: 1
+                }
+              }}
+              initial="hidden"
+              animate={selectedIndices.includes(cardIndex) ? "selected" : "visible"}
+            />
+          );
+        })}
+      </CardRow>
+    );
+  });
+
+  return <DeckContainer>{rows}</DeckContainer>;
+} 

--- a/src/Components/Input.tsx
+++ b/src/Components/Input.tsx
@@ -36,7 +36,7 @@ export default function Input({ onFormSubmit }: InputProps) {
           rows={5}
           maxLength={maxLength}
         />
-        <CharCount isAtLimit={inputValue.length === maxLength}>
+        <CharCount $isAtLimit={inputValue.length === maxLength}>
           {inputValue.length}/{maxLength}
         </CharCount>
         <CommonButton 

--- a/src/Components/SpreadDisplay.tsx
+++ b/src/Components/SpreadDisplay.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { DrawnTarotCard } from '../Types/tarotCard';
 import {
@@ -27,31 +27,59 @@ interface SpreadDisplayProps {
 
 export default function SpreadDisplay({ 
   cards, 
-  revealed = false,
-  onAllCardsRevealed,
-  visibleCardCount = 0
+  revealed, 
+  onAllCardsRevealed, 
+  visibleCardCount = 0 
 }: SpreadDisplayProps) {
+  const [delayedVisibleCount, setDelayedVisibleCount] = useState(0);
   const [revealedCount, setRevealedCount] = useState(0);
+
+  useEffect(() => {
+    if (visibleCardCount > delayedVisibleCount) {
+      const timer = setTimeout(() => {
+        setDelayedVisibleCount(visibleCardCount);
+      }, 300);
+      
+      return () => clearTimeout(timer);
+    } else {
+      setDelayedVisibleCount(visibleCardCount);
+    }
+  }, [visibleCardCount]);
 
   const handleCardReveal = () => {
     const newCount = revealedCount + 1;
     setRevealedCount(newCount);
     
-    if (newCount === cards.length && onAllCardsRevealed) {
-      onAllCardsRevealed();
+    if (newCount === cards.length) {
+      onAllCardsRevealed?.();
     }
   };
 
   const renderSpread = () => {
     switch (cards.length) {
       case 1:
-        return <SingleSpread cards={cards} revealed={revealed} onReveal={handleCardReveal} visibleCardCount={visibleCardCount} />;
+        return <SingleSpread cards={cards} revealed={revealed} onReveal={() => handleCardReveal()} visibleCardCount={delayedVisibleCount} />;
       case 3:
-        return <TripleSpread cards={cards} revealed={revealed} onReveal={handleCardReveal} visibleCardCount={visibleCardCount} />;
+        return <TripleSpread 
+          cards={cards} 
+          revealed={revealed} 
+          visibleCardCount={delayedVisibleCount}
+          onReveal={() => handleCardReveal()} 
+        />;
       case 5:
-        return <FiveCardCross cards={cards} revealed={revealed} onReveal={handleCardReveal} visibleCardCount={visibleCardCount} />;
+        return <FiveCardCross 
+          cards={cards} 
+          revealed={revealed} 
+          visibleCardCount={delayedVisibleCount}
+          onReveal={() => handleCardReveal()} 
+        />;
       case 10:
-        return <CelticCrossSpread cards={cards} revealed={revealed} onReveal={handleCardReveal} visibleCardCount={visibleCardCount} />;
+        return <CelticCrossSpread 
+          cards={cards} 
+          revealed={revealed} 
+          visibleCardCount={delayedVisibleCount}
+          onReveal={handleCardReveal} 
+        />;
       default:
         return null;
     }

--- a/src/Components/SpreadDisplay.tsx
+++ b/src/Components/SpreadDisplay.tsx
@@ -78,7 +78,7 @@ export default function SpreadDisplay({
           cards={cards} 
           revealed={revealed} 
           visibleCardCount={delayedVisibleCount}
-          onReveal={handleCardReveal} 
+          onReveal={() => handleCardReveal()} 
         />;
       default:
         return null;

--- a/src/Components/Spreads/CelticCrossSpread.tsx
+++ b/src/Components/Spreads/CelticCrossSpread.tsx
@@ -41,7 +41,7 @@ export default function CelticCrossSpread({
       <Card 
         card={cards[cardIndex]} 
         isRevealed={revealed} 
-        onReveal={cardIndex === 9 ? onReveal : undefined}
+        onReveal={onReveal}
       />
     </CardContainer>
   );

--- a/src/Components/Spreads/CelticCrossSpread.tsx
+++ b/src/Components/Spreads/CelticCrossSpread.tsx
@@ -1,6 +1,8 @@
 import { DrawnTarotCard } from '../../Types/tarotCard';
 import Card from '../Card';
 import { CelticCrossContainer, GridContainer } from './styles/CelticCross.styles';
+import styled from 'styled-components';
+import { motion } from 'framer-motion';
 
 interface SpreadProps {
   cards: DrawnTarotCard[];
@@ -9,6 +11,11 @@ interface SpreadProps {
   visibleCardCount?: number;
 }
 
+const CardContainer = styled(motion.div)<{ $visibleCardCount: number; $index: number }>`
+  pointer-events: ${props => props.$visibleCardCount > props.$index ? 'auto' : 'none'};
+  height: 100%;
+`;
+
 export default function CelticCrossSpread({ 
   cards, 
   revealed = false, 
@@ -16,6 +23,28 @@ export default function CelticCrossSpread({
   visibleCardCount = 0 
 }: SpreadProps) {
   if (cards.length < 10) return null;
+
+  const renderCard = (cardIndex: number) => (
+    <CardContainer
+      $visibleCardCount={visibleCardCount}
+      $index={cardIndex}
+      initial={{ y: -50, opacity: 0 }}
+      animate={{ 
+        y: visibleCardCount > cardIndex ? 0 : -50,
+        opacity: visibleCardCount > cardIndex ? 1 : 0
+      }}
+      transition={{
+        duration: 0.5,
+        ease: "easeOut"
+      }}
+    >
+      <Card 
+        card={cards[cardIndex]} 
+        isRevealed={revealed} 
+        onReveal={cardIndex === 9 ? onReveal : undefined}
+      />
+    </CardContainer>
+  );
 
   return (
     <CelticCrossContainer>
@@ -28,7 +57,7 @@ export default function CelticCrossSpread({
             height: '100%',
             zIndex: 2
           }}>
-            <Card card={cards[1]} isRevealed={revealed} onReveal={onReveal} />
+            {renderCard(1)}
           </div>
         </div>
 
@@ -40,7 +69,7 @@ export default function CelticCrossSpread({
             height: '100%',
             zIndex: 1
           }}>
-            <Card card={cards[0]} isRevealed={revealed} onReveal={onReveal} />
+            {renderCard(0)}
           </div>
         </div>
 
@@ -51,7 +80,7 @@ export default function CelticCrossSpread({
             pointerEvents: visibleCardCount > 2 ? 'auto' : 'none',
             height: '100%'
           }}>
-            <Card card={cards[2]} isRevealed={revealed} onReveal={onReveal} />
+            {renderCard(2)}
           </div>
         </div>
 
@@ -62,7 +91,7 @@ export default function CelticCrossSpread({
             pointerEvents: visibleCardCount > 3 ? 'auto' : 'none',
             height: '100%'
           }}>
-            <Card card={cards[3]} isRevealed={revealed} onReveal={onReveal} />
+            {renderCard(3)}
           </div>
         </div>
 
@@ -73,7 +102,7 @@ export default function CelticCrossSpread({
             pointerEvents: visibleCardCount > 4 ? 'auto' : 'none',
             height: '100%'
           }}>
-            <Card card={cards[4]} isRevealed={revealed} onReveal={onReveal} />
+            {renderCard(4)}
           </div>
         </div>
 
@@ -84,7 +113,7 @@ export default function CelticCrossSpread({
             pointerEvents: visibleCardCount > 5 ? 'auto' : 'none',
             height: '100%'
           }}>
-            <Card card={cards[5]} isRevealed={revealed} onReveal={onReveal} />
+            {renderCard(5)}
           </div>
         </div>
 
@@ -96,7 +125,7 @@ export default function CelticCrossSpread({
               pointerEvents: visibleCardCount > (9 - index) ? 'auto' : 'none',
               height: '100%'
             }}>
-              <Card card={cards[9 - index]} isRevealed={revealed} onReveal={onReveal} />
+              {renderCard(9 - index)}
             </div>
           </div>
         ))}

--- a/src/Components/Spreads/FiveCardCross.tsx
+++ b/src/Components/Spreads/FiveCardCross.tsx
@@ -44,7 +44,7 @@ export default function FiveCardCross({
       <Card 
         card={cards[cardIndex]} 
         isRevealed={revealed} 
-        onReveal={cardIndex === 4 ? onReveal : undefined}
+        onReveal={onReveal}
       />
     </CardContainer>
   );

--- a/src/Components/Spreads/FiveCardCross.tsx
+++ b/src/Components/Spreads/FiveCardCross.tsx
@@ -1,9 +1,11 @@
+import styled from 'styled-components';
 import { DrawnTarotCard } from '../../Types/tarotCard';
 import Card from '../Card';
 import { 
   CrossContainer,
   GridContainer 
 } from './styles/FiveCardCross.styles'
+import { motion } from 'motion/react';
 
 interface SpreadProps {
   cards: DrawnTarotCard[];
@@ -11,6 +13,11 @@ interface SpreadProps {
   onReveal?: () => void;
   visibleCardCount?: number;
 }
+
+const CardContainer = styled(motion.div)<{ $visibleCardCount: number; $index: number }>`
+  pointer-events: ${props => props.$visibleCardCount > props.$index ? 'auto' : 'none'};
+  height: 100%;
+`;
 
 export default function FiveCardCross({ 
   cards, 
@@ -20,63 +27,50 @@ export default function FiveCardCross({
 }: SpreadProps) {
   if (cards.length < 5) return null;
 
+  const renderCard = (cardIndex: number) => (
+    <CardContainer
+      $visibleCardCount={visibleCardCount}
+      $index={cardIndex}
+      initial={{ y: -50, opacity: 0 }}
+      animate={{ 
+        y: visibleCardCount > cardIndex ? 0 : -50,
+        opacity: visibleCardCount > cardIndex ? 1 : 0
+      }}
+      transition={{
+        duration: 0.5,
+        ease: "easeOut"
+      }}
+    >
+      <Card 
+        card={cards[cardIndex]} 
+        isRevealed={revealed} 
+        onReveal={cardIndex === 4 ? onReveal : undefined}
+      />
+    </CardContainer>
+  );
+
   return (
     <CrossContainer>
       <GridContainer>
         <div className="empty" />
         <div className="card-slot">
-          <div style={{ 
-            opacity: visibleCardCount > 4 ? 1 : 0,
-            transition: 'opacity 0.3s ease',
-            pointerEvents: visibleCardCount > 4 ? 'auto' : 'none',
-            height: '100%'
-          }}>
-            <Card card={cards[4]} isRevealed={revealed} onReveal={onReveal} />
-          </div>
+          {renderCard(4)}
         </div>
         <div className="empty" />
         
         <div className="card-slot">
-          <div style={{ 
-            opacity: visibleCardCount > 1 ? 1 : 0,
-            transition: 'opacity 0.3s ease',
-            pointerEvents: visibleCardCount > 1 ? 'auto' : 'none',
-            height: '100%'
-          }}>
-            <Card card={cards[1]} isRevealed={revealed} onReveal={onReveal} />
-          </div>
+          {renderCard(1)}
         </div>
         <div className="card-slot">
-          <div style={{ 
-            opacity: visibleCardCount > 0 ? 1 : 0,
-            transition: 'opacity 0.3s ease',
-            pointerEvents: visibleCardCount > 0 ? 'auto' : 'none',
-            height: '100%'
-          }}>
-            <Card card={cards[0]} isRevealed={revealed} onReveal={onReveal} />
-          </div>
+          {renderCard(0)}
         </div>
         <div className="card-slot">
-          <div style={{ 
-            opacity: visibleCardCount > 2 ? 1 : 0,
-            transition: 'opacity 0.3s ease',
-            pointerEvents: visibleCardCount > 2 ? 'auto' : 'none',
-            height: '100%'
-          }}>
-            <Card card={cards[2]} isRevealed={revealed} onReveal={onReveal} />
-          </div>
+          {renderCard(2)}
         </div>
         
         <div className="empty" />
         <div className="card-slot">
-          <div style={{ 
-            opacity: visibleCardCount > 3 ? 1 : 0,
-            transition: 'opacity 0.3s ease',
-            pointerEvents: visibleCardCount > 3 ? 'auto' : 'none',
-            height: '100%'
-          }}>
-            <Card card={cards[3]} isRevealed={revealed} onReveal={onReveal} />
-          </div>
+          {renderCard(3)}
         </div>
         <div className="empty" />
       </GridContainer>

--- a/src/Components/Spreads/SingleSpread.tsx
+++ b/src/Components/Spreads/SingleSpread.tsx
@@ -1,6 +1,8 @@
+import styled from 'styled-components';
 import { DrawnTarotCard } from '../../Types/tarotCard';
 import Card from '../Card';
 import { SingleSpreadContainer } from './styles/SingleSpread.styles';
+import { motion } from 'motion/react';
 
 interface SpreadProps {
   cards: DrawnTarotCard[];
@@ -8,6 +10,11 @@ interface SpreadProps {
   onReveal?: () => void;
   visibleCardCount?: number;
 }
+
+const CardContainer = styled(motion.div)<{ $visibleCardCount: number; $index: number }>`
+  pointer-events: ${props => props.$visibleCardCount > props.$index ? 'auto' : 'none'};
+  height: 100%;
+`;
 
 export default function SingleSpread({ 
   cards, 
@@ -19,18 +26,24 @@ export default function SingleSpread({
   
   return (
     <SingleSpreadContainer>
-      <div style={{ 
-        opacity: visibleCardCount > 0 ? 1 : 0,
-        transition: 'opacity 0.3s ease',
-        pointerEvents: visibleCardCount > 0 ? 'auto' : 'none',
-        height: '100%'
-      }}>
+      <CardContainer 
+        $visibleCardCount={visibleCardCount}
+        initial={{ y: -50, opacity: 0 }}
+        animate={{ 
+          y: visibleCardCount > 0 ? 0 : -50,
+          opacity: visibleCardCount > 0 ? 1 : 0
+        }}
+        transition={{
+          duration: 0.5,
+          ease: "easeOut"
+        }}
+      >
         <Card 
           card={cards[0]} 
           isRevealed={revealed} 
           onReveal={onReveal}
         />
-      </div>
+      </CardContainer>
     </SingleSpreadContainer>
   );
 } 

--- a/src/Components/Spreads/SingleSpread.tsx
+++ b/src/Components/Spreads/SingleSpread.tsx
@@ -28,6 +28,7 @@ export default function SingleSpread({
     <SingleSpreadContainer>
       <CardContainer 
         $visibleCardCount={visibleCardCount}
+        $index={0}
         initial={{ y: -50, opacity: 0 }}
         animate={{ 
           y: visibleCardCount > 0 ? 0 : -50,

--- a/src/Components/Spreads/TripleSpread.tsx
+++ b/src/Components/Spreads/TripleSpread.tsx
@@ -1,9 +1,8 @@
+import styled from 'styled-components';
 import { DrawnTarotCard } from '../../Types/tarotCard';
 import Card from '../Card';
-import { 
-  TripleSpreadContainer,
-  CardsRow 
-} from './styles/TripleSpread.styles';
+import { TripleSpreadContainer } from './styles/TripleSpread.styles';
+import { motion } from 'motion/react';
 
 interface SpreadProps {
   cards: DrawnTarotCard[];
@@ -12,32 +11,43 @@ interface SpreadProps {
   visibleCardCount?: number;
 }
 
+const CardContainer = styled(motion.div)<{ $visibleCardCount: number; $index: number }>`
+  pointer-events: ${props => props.$visibleCardCount > props.$index ? 'auto' : 'none'};
+  height: 100%;
+`;
+
 export default function TripleSpread({ 
   cards, 
   revealed = false, 
   onReveal,
-  visibleCardCount = cards.length 
+  visibleCardCount = 0
 }: SpreadProps) {
+  if (!cards.length) return null;
+
   return (
     <TripleSpreadContainer>
-      <CardsRow>
-        {cards.map((card, index) => (
-          <div 
-            key={index}
-            style={{ 
-              opacity: index < visibleCardCount ? 1 : 0,
-              transition: 'opacity 0.3s ease',
-              pointerEvents: index < visibleCardCount ? 'auto' : 'none'
-            }}
-          >
-            <Card 
-              card={card}
-              isRevealed={revealed}
-              onReveal={onReveal}
-            />
-          </div>
-        ))}
-      </CardsRow>
+      {cards.slice(0, 3).map((card, index) => (
+        <CardContainer 
+          key={index}
+          $visibleCardCount={visibleCardCount}
+          $index={index}
+          initial={{ y: -50, opacity: 0 }}
+          animate={{ 
+            y: visibleCardCount > index ? 0 : -50,
+            opacity: visibleCardCount > index ? 1 : 0
+          }}
+          transition={{
+            duration: 0.5,
+            ease: "easeOut"
+          }}
+        >
+          <Card 
+            card={card} 
+            isRevealed={revealed} 
+            onReveal={index === 2 ? onReveal : undefined}
+          />
+        </CardContainer>
+      ))}
     </TripleSpreadContainer>
   );
 } 

--- a/src/Components/Spreads/TripleSpread.tsx
+++ b/src/Components/Spreads/TripleSpread.tsx
@@ -44,7 +44,7 @@ export default function TripleSpread({
           <Card 
             card={card} 
             isRevealed={revealed} 
-            onReveal={index === 2 ? onReveal : undefined}
+            onReveal={onReveal}
           />
         </CardContainer>
       ))}

--- a/src/Components/styles/Input.styles.ts
+++ b/src/Components/styles/Input.styles.ts
@@ -22,11 +22,11 @@ export const StyledTextArea = styled.textarea`
   }
 `;
 
-export const CharCount = styled.div<{ isAtLimit: boolean }>`
+export const CharCount = styled.div<{ $isAtLimit: boolean }>`
   align-self: flex-end;
   margin-bottom: 5px;
   padding-right: 8px;
-  color: ${props => props.isAtLimit ? '#ff4444' : '#666'};
+  color: ${props => props.$isAtLimit ? '#ff4444' : '#666'};
   font-size: 14px;
   transition: color 0.2s ease;
 `; 

--- a/src/Pages/DrawPage.tsx
+++ b/src/Pages/DrawPage.tsx
@@ -7,6 +7,7 @@ import { formatUserInputAndCardInfo } from '../utils/formatUserInputAndCardInfo'
 import { callVertexAPI } from '../api/callVertexApi';
 import SpreadDisplay from '../Components/SpreadDisplay';
 import DrawPhaseDisplay from '../Components/DrawPhaseDisplay';
+import { motion, AnimatePresence } from 'motion/react';
 
 // 스타일 컴포넌트
 const DrawPageContainer = styled.div`
@@ -42,6 +43,10 @@ const FlavorText = styled.div<{ $visible: boolean }>`
   font-size: 1.2rem;
   text-align: center;
   margin: 20px 0;
+`;
+
+const AnimatedDrawPhase = styled(motion.div)`
+  width: 100%;
 `;
 
 type DrawPhase = 'shuffle' | 'cut' | 'draw' | 'reveal';
@@ -131,10 +136,26 @@ export default function DrawPage() {
 
       {currentPhase === 'draw' && (
         <>
-          <DrawPhaseDisplay
-            onCardSelect={handleCardSelect}
-            selectedIndices={selectedCardIndices}
-          />
+          <AnimatePresence>
+            {selectedCardIndices.length < cardCount && (
+              <AnimatedDrawPhase
+                initial={{ opacity: 1, height: 'auto' }}
+                exit={{ 
+                  opacity: 0, 
+                  height: 0,
+                  transition: {
+                    opacity: { duration: 0.5, delay: 0.5 },
+                    height: { duration: 0.7, delay: 0.7 }
+                  }
+                }}
+              >
+                <DrawPhaseDisplay
+                  onCardSelect={handleCardSelect}
+                  selectedIndices={selectedCardIndices}
+                />
+              </AnimatedDrawPhase>
+            )}
+          </AnimatePresence>
           <SpreadDisplay
             cards={drawnCards}
             revealed={cardsRevealed}

--- a/src/Pages/DrawPage.tsx
+++ b/src/Pages/DrawPage.tsx
@@ -6,6 +6,7 @@ import { drawRandomCards } from '../utils/drawRandomCards';
 import { formatUserInputAndCardInfo } from '../utils/formatUserInputAndCardInfo';
 import { callVertexAPI } from '../api/callVertexApi';
 import SpreadDisplay from '../Components/SpreadDisplay';
+import DrawPhaseDisplay from '../Components/DrawPhaseDisplay';
 
 // 스타일 컴포넌트
 const DrawPageContainer = styled.div`
@@ -35,34 +36,12 @@ const PhaseButton = styled.button`
   }
 `;
 
-const CardsGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(13, 1fr);
-  gap: 8px;
-  width: 100%;
-  max-width: 1200px;
-`;
-
-const CardButton = styled.button<{ $isSelected: boolean }>`
-  aspect-ratio: 1/1.4;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  cursor: pointer;
-  opacity: ${props => props.$isSelected ? 0.5 : 1};
-  
-  &:disabled {
-    cursor: not-allowed;
-  }
-`;
-
 const FlavorText = styled.div<{ $visible: boolean }>`
-  font-size: 1.2rem;
-  color: #2c3e50;
-  text-align: center;
   opacity: ${props => props.$visible ? 1 : 0};
   transition: opacity 0.5s ease;
-  margin-top: 16px;
-  font-style: italic;
+  font-size: 1.2rem;
+  text-align: center;
+  margin: 20px 0;
 `;
 
 type DrawPhase = 'shuffle' | 'cut' | 'draw' | 'reveal';
@@ -151,18 +130,10 @@ export default function DrawPage() {
 
       {currentPhase === 'draw' && (
         <>
-          <CardsGrid>
-            {Array.from({ length: 78 }, (_, i) => (
-              <CardButton
-                key={i}
-                $isSelected={selectedCardIndices.includes(i)}
-                disabled={selectedCardIndices.includes(i)}
-                onClick={() => handleCardSelect(i)}
-              >
-                {i + 1}
-              </CardButton>
-            ))}
-          </CardsGrid>
+          <DrawPhaseDisplay
+            onCardSelect={handleCardSelect}
+            selectedIndices={selectedCardIndices}
+          />
           <SpreadDisplay
             cards={drawnCards}
             revealed={cardsRevealed}

--- a/src/Pages/DrawPage.tsx
+++ b/src/Pages/DrawPage.tsx
@@ -78,6 +78,7 @@ export default function DrawPage() {
           const fetchedApiResponse = await callVertexAPI(formattedQuery);
           const responseText = fetchedApiResponse.content?.[0]?.text || '';
           setApiResponse(responseText);
+          console.log(responseText);
         } catch (error) {
           console.error('API 요청 오류:', error);
           setApiResponse('API 요청에 실패했습니다.');

--- a/src/Pages/DrawTestPage.tsx
+++ b/src/Pages/DrawTestPage.tsx
@@ -4,6 +4,7 @@ import { DrawnTarotCard } from '../Types/tarotCard';
 import { drawRandomCards } from '../utils/drawRandomCards';
 import SpreadDisplay from '../Components/SpreadDisplay';
 import SpreadSelector from '../Components/SpreadSelector';
+import DrawPhaseDisplay from '../Components/DrawPhaseDisplay';
 
 const TestPageContainer = styled.div`
   display: flex;
@@ -28,25 +29,25 @@ const StartButton = styled.button`
   }
 `;
 
-const CardsGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(13, 1fr);
-  gap: 8px;
-  width: 100%;
-  max-width: 1200px;
-`;
+// const CardsGrid = styled.div`
+//   display: grid;
+//   grid-template-columns: repeat(13, 1fr);
+//   gap: 8px;
+//   width: 100%;
+//   max-width: 1200px;
+// `;
 
-const CardButton = styled.button<{ $isSelected: boolean }>`
-  aspect-ratio: 1/1.4;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  cursor: pointer;
-  opacity: ${props => props.$isSelected ? 0.5 : 1};
+// const CardButton = styled.button<{ $isSelected: boolean }>`
+//   aspect-ratio: 1/1.4;
+//   border: 1px solid #ddd;
+//   border-radius: 4px;
+//   cursor: pointer;
+//   opacity: ${props => props.$isSelected ? 0.5 : 1};
   
-  &:disabled {
-    cursor: not-allowed;
-  }
-`;
+//   &:disabled {
+//     cursor: not-allowed;
+//   }
+// `;
 
 const CardInfo = styled.div`
   width: 100%;
@@ -113,7 +114,7 @@ export default function DrawTestPage() {
         </>
       ) : (
         <>
-          <CardsGrid>
+          {/* <CardsGrid>
             {Array.from({ length: 78 }, (_, i) => (
               <CardButton
                 key={i}
@@ -124,7 +125,11 @@ export default function DrawTestPage() {
                 {i + 1}
               </CardButton>
             ))}
-          </CardsGrid>
+          </CardsGrid> */}
+          <DrawPhaseDisplay
+            onCardSelect={handleCardSelect}
+            selectedIndices={selectedCardIndices}
+          />
           <SpreadDisplay
             cards={drawnCards}
             revealed={false}

--- a/src/Pages/DrawTestPage.tsx
+++ b/src/Pages/DrawTestPage.tsx
@@ -5,6 +5,7 @@ import { drawRandomCards } from '../utils/drawRandomCards';
 import SpreadDisplay from '../Components/SpreadDisplay';
 import SpreadSelector from '../Components/SpreadSelector';
 import DrawPhaseDisplay from '../Components/DrawPhaseDisplay';
+import { motion, AnimatePresence } from 'motion/react';
 
 const TestPageContainer = styled.div`
   display: flex;
@@ -58,6 +59,27 @@ const CardInfo = styled.div`
   font-family: monospace;
   white-space: pre-wrap;
   word-break: break-all;
+`;
+
+const AnimatedDrawPhase = styled(motion.div)`
+  width: 100%;
+  margin-bottom: 32px;
+`;
+
+const AnimatedSpread = styled(motion.div)`
+  width: 100%;
+  opacity: 0;
+  animation: fadeIn 0.3s ease-in forwards;
+  animation-delay: 0.3s;
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
 `;
 
 export default function DrawTestPage() {
@@ -114,28 +136,34 @@ export default function DrawTestPage() {
         </>
       ) : (
         <>
-          {/* <CardsGrid>
-            {Array.from({ length: 78 }, (_, i) => (
-              <CardButton
-                key={i}
-                $isSelected={selectedCardIndices.includes(i)}
-                disabled={selectedCardIndices.includes(i)}
-                onClick={() => handleCardSelect(i)}
+          <AnimatePresence>
+            {selectedCardIndices.length < cardCount && (
+              <AnimatedDrawPhase
+                initial={{ opacity: 1, height: 'auto' }}
+                exit={{ 
+                  opacity: 0, 
+                  height: 0,
+                  transition: {
+                    opacity: { duration: 0.5, delay: 0.5 },
+                    height: { duration: 0.7, delay: 0.7 }
+                  }
+                }}
               >
-                {i + 1}
-              </CardButton>
-            ))}
-          </CardsGrid> */}
-          <DrawPhaseDisplay
-            onCardSelect={handleCardSelect}
-            selectedIndices={selectedCardIndices}
-          />
-          <SpreadDisplay
-            cards={drawnCards}
-            revealed={false}
-            onAllCardsRevealed={handleAllCardsRevealed}
-            visibleCardCount={selectedCardIndices.length}
-          />
+                <DrawPhaseDisplay
+                  onCardSelect={handleCardSelect}
+                  selectedIndices={selectedCardIndices}
+                />
+              </AnimatedDrawPhase>
+            )}
+          </AnimatePresence>
+          <AnimatedSpread>
+            <SpreadDisplay
+              cards={drawnCards}
+              revealed={false}
+              onAllCardsRevealed={handleAllCardsRevealed}
+              visibleCardCount={selectedCardIndices.length}
+            />
+          </AnimatedSpread>
         </>
       )}
     </TestPageContainer>


### PR DESCRIPTION
- DrawPhaseDisplay(이하 DPD) 컴포넌트를 구현하여, 드로우 페이즈 진입 시 뒷면 카드 78장이 렌더링되게끔 구현
- 카드 선택 시 해당 카드는 아래로 "뽑혀나가는" 애니메이션을 보여주도록 구현
- SpreadDisplay를 수정하여, 카드가 visible해질 때 위에서 아래로 내려오도록 구현
- 페이지에 애니메이션을 추가하여 드로우 페이즈가 종료될 때 DPD를 애니메이션과 함께 exit시킴
- minor change: styled-components의 커스텀 프롭을 사용할 때 앞에 달러사인$을 붙여서 해당 프롭이 DOM에 전달되지 않게끔 처리