### PR TITLE
feat: 네비게이션 관련 UX 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import styled from 'styled-components';
 import LandingPage from './Pages/LandingPage';
+import HomePage from './Pages/HomePage';
 import QueryPage from './Pages/QueryPage';
 import ResultPage from './Pages/ResultPage';
 import DrawPage from './Pages/DrawPage';
@@ -56,6 +57,14 @@ function App() {
 
   const [appContainer, setAppContainer] = useState<HTMLDivElement | null>(null);
 
+  // 첫 방문 체크
+  const hasVisited = localStorage.getItem('hasVisited');
+  
+  // 첫 방문이면 localStorage에 표시
+  if (!hasVisited) {
+    localStorage.setItem('hasVisited', 'true');
+  }
+
   return (
     <RecoilRoot>
       <GlobalStyle />
@@ -64,7 +73,14 @@ function App() {
           <AppContainer ref={containerRef}>
             <Router>
               <Routes>
-                <Route path="/" element={<LandingPage />} />
+                <Route 
+                  path="/" 
+                  element={
+                    hasVisited ? <Navigate to="/home" /> : <Navigate to="/landing" />
+                  } 
+                />
+                <Route path="/landing" element={<LandingPage />} />
+                <Route path="/home" element={<HomePage />} />
                 <Route path="/query" element={<QueryPage />} />
                 <Route path="/draw" element={<DrawPage />} />
                 <Route path="/result" element={<ResultPage />} />

--- a/src/Components/Input.tsx
+++ b/src/Components/Input.tsx
@@ -41,7 +41,7 @@ export default function Input({ onFormSubmit }: InputProps) {
         </CharCount>
         <CommonButton 
           type="submit" 
-          disabled={inputValue.length > maxLength}
+          disabled={inputValue.length > maxLength || inputValue.length === 0}
         >
           운세 보기
         </CommonButton>

--- a/src/Pages/DrawPage.tsx
+++ b/src/Pages/DrawPage.tsx
@@ -99,7 +99,14 @@ export default function DrawPage() {
   // 결과 페이지로 이동
   useEffect(() => {
     if (readyToNavigate && apiResponse) {
-      navigate('/result', { state: { userInput, apiResponse, drawnCards } });
+      navigate('/result', {
+        replace:true, 
+        state: {
+          userInput,
+          apiResponse,
+          drawnCards 
+        } 
+      });
     }
   }, [readyToNavigate, apiResponse, navigate, userInput, drawnCards]);
 

--- a/src/Pages/HomePage.tsx
+++ b/src/Pages/HomePage.tsx
@@ -1,0 +1,28 @@
+import { useNavigate } from 'react-router-dom';
+import { Container, Header, Logo, ServiceGrid, ServiceCard } from './styles/HomePage.styles';
+
+export default function HomePage() {
+  const navigate = useNavigate();
+  
+  return (
+    <Container>
+      <Header>
+        <Logo src="/logo-typo.png" alt="Moonstruck" />
+      </Header>
+      
+      <ServiceGrid>
+        <ServiceCard onClick={() => navigate('/query')}>
+          <h2>타로 상담</h2>
+          <p>당신의 고민을 입력하고 타로 카드로 점쳐보세요</p>
+        </ServiceCard>
+        
+        <ServiceCard onClick={() => navigate('/daily')}>
+          <h2>오늘의 운세</h2>
+          <p>오늘 하루의 운세를 확인해보세요</p>
+        </ServiceCard>
+        
+        {/* 추가 기능들을 위한 카드 */}
+      </ServiceGrid>
+    </Container>
+  );
+}

--- a/src/Pages/ResultPage.tsx
+++ b/src/Pages/ResultPage.tsx
@@ -1,15 +1,17 @@
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import {
   Container,
   Section,
   Title,
-  Text
+  Text,
+  HomeButton
 } from './styles/ResultPage.styles';
 import SpreadDisplay from '../Components/SpreadDisplay';
 
 export default function ResultPage() {
   const location = useLocation();
+  const navigate = useNavigate();
   const { userInput, apiResponse, drawnCards } = location.state || {};
 
   if (!apiResponse || !drawnCards) {
@@ -36,6 +38,10 @@ export default function ResultPage() {
         <Title>타로 해석</Title>
         <Text>{apiResponse}</Text>
       </Section>
+
+      <HomeButton onClick={() => navigate('/')}>
+        홈으로 돌아가기
+      </HomeButton>
     </Container>
   );
 }

--- a/src/Pages/styles/HomePage.styles.ts
+++ b/src/Pages/styles/HomePage.styles.ts
@@ -1,0 +1,58 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  width: 100%;
+  min-height: 100vh;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: #f8f9fa;
+`;
+
+export const Header = styled.header`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin-bottom: 3rem;
+`;
+
+export const Logo = styled.img`
+  width: 100%;
+  max-width: 400px;
+  height: auto;
+  margin-bottom: 20px;
+`;
+
+export const ServiceGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  width: 100%;
+  max-width: 1200px;
+`;
+
+export const ServiceCard = styled.div`
+  background: white;
+  border-radius: 1rem;
+  padding: 2rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  transition: transform 0.2s ease;
+
+  &:hover {
+    transform: translateY(-5px);
+  }
+
+  h2 {
+    margin: 0 0 1rem 0;
+    font-size: 1.5rem;
+    color: #333;
+  }
+
+  p {
+    margin: 0;
+    color: #666;
+    font-size: 1rem;
+  }
+`;

--- a/src/Pages/styles/ResultPage.styles.ts
+++ b/src/Pages/styles/ResultPage.styles.ts
@@ -27,3 +27,20 @@ export const Text = styled.p`
   white-space: pre-wrap;
   line-height: 1.6;
 `; 
+
+
+export const HomeButton = styled.button`
+  margin-top: 2rem;
+  padding: 1rem 2rem;
+  background-color: #6c5ce7;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: #5f3dc4;
+  }
+`;


### PR DESCRIPTION
### 내용
- 홈 페이지 구현, 랜딩페이지와 홈페이지 리디렉션 로직 구현
  - 로컬스토리지에 hasVisited가 true이면 바로 홈으로, 아니면(=첫방문) 랜딩페이지 보여주기
  - 홈 페이지 => 여러 기능(현재는 질문 입력하고 점치는 기능밖에 없지만, 오늘의 운세, 궁합점(??)등 새 기능이 추가하면 여기서 네비게이트하게 할거임)
  - result 페이지에 홈 화면으로 돌아가기 버튼 추가
  - result 페이지에서 뒤로가기하면 draw로 가서 API 요청이 불필요하게 반복 실행되는 것을 해결하기 위해 replace: true 옵션 추가 (이전 페이지인 query로 돌아가게 함)
  - Input: 입력값이 없으면 제출 버튼 비활성화 기능 추가

예상 효과: UX 만족도 350% 향상
