### PR TITLE
feat: 공유용 페이지 별도 생성

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import React, { useRef, useEffect, useState } from 'react';
 import SpreadTestPage from './Pages/SpreadTestPage';
 import DrawTestPage from './Pages/DrawTestPage';
 import DeckTestPage from './Pages/DeckTestPage';
+import SharePage from './Pages/SharePage';
 
 const AppContainer = styled.div`
   max-width: 480px;
@@ -88,6 +89,7 @@ function App() {
                 <Route path="/spread-test" element={<SpreadTestPage />} />
                 <Route path="/draw-test" element={<DrawTestPage />} />
                 <Route path="/deck-test" element={<DeckTestPage />} />
+                <Route path="/share/:readingId" element={<SharePage />} />
               </Routes>
             </Router>
           </AppContainer>

--- a/src/Components/LoadingSpinner.tsx
+++ b/src/Components/LoadingSpinner.tsx
@@ -1,0 +1,38 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCircleNotch } from '@fortawesome/free-solid-svg-icons';
+import styled from 'styled-components';
+import { motion } from 'motion/react';
+
+const SpinnerContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  min-height: 100vh;
+  width: 100%;
+  background-color: white;
+`;
+
+const SpinnerText = styled.p`
+  font-size: 1.1rem;
+  color: #666;
+`;
+
+export default function LoadingSpinner() {
+  return (
+    <SpinnerContainer>
+      <motion.div
+        animate={{ rotate: 360 }}
+        transition={{
+          duration: 1,
+          repeat: Infinity,
+          ease: "linear"
+        }}
+      >
+        <FontAwesomeIcon icon={faCircleNotch} size="2x" color="#6c5ce7" />
+      </motion.div>
+      <SpinnerText>로딩중...</SpinnerText>
+    </SpinnerContainer>
+  );
+} 

--- a/src/Components/QuestionReadingDisplay.tsx
+++ b/src/Components/QuestionReadingDisplay.tsx
@@ -1,0 +1,36 @@
+import { QuestionReading } from '../Types/tarotReading';
+import {
+  Section,
+  Title,
+  Text,
+} from './styles/ReadingDisplay.styles';
+import SpreadDisplay from './SpreadDisplay';
+
+interface QuestionReadingDisplayProps {
+  reading: QuestionReading;
+}
+
+export default function QuestionReadingDisplay({ reading }: QuestionReadingDisplayProps) {
+  return (
+    <>
+      <Section>
+        <Title>사용자 입력</Title>
+        <Text>{reading.question}</Text>
+      </Section>
+
+      <Section>
+        <Title>뽑힌 카드</Title>
+        <SpreadDisplay 
+          cards={reading.cards} 
+          revealed={true}
+          visibleCardCount={reading.cards.length}
+        />
+      </Section>
+
+      <Section>
+        <Title>타로 해석</Title>
+        <Text>{reading.interpretation}</Text>
+      </Section>
+    </>
+  );
+} 

--- a/src/Components/styles/ReadingDisplay.styles.ts
+++ b/src/Components/styles/ReadingDisplay.styles.ts
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+
+export const Section = styled.div`
+  margin-bottom: 40px;
+`;
+
+export const Title = styled.h2`
+  color: #333;
+  margin-bottom: 20px;
+`;
+
+export const Text = styled.p`
+  white-space: pre-wrap;
+  line-height: 1.6;
+`;
+
+export const CardsContainer = styled.div`
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin: 20px 0;
+`; 

--- a/src/Pages/DrawPage.tsx
+++ b/src/Pages/DrawPage.tsx
@@ -110,10 +110,18 @@ export default function DrawPage() {
   useEffect(() => {
     if (readyToNavigate && apiResponse && readingId) {
       navigate(`/result/${readingId}`, {
-        replace: true
+        replace: true,
+        state: {
+          reading: {
+            question: userInput,
+            cards: drawnCards,
+            interpretation: apiResponse,
+            id: readingId
+          }
+        }
       });
     }
-  }, [readyToNavigate, apiResponse, readingId, navigate]);
+  }, [readyToNavigate, apiResponse, readingId, navigate, userInput, drawnCards]);
 
   return (
     <DrawPageContainer>

--- a/src/Pages/SharePage.tsx
+++ b/src/Pages/SharePage.tsx
@@ -1,0 +1,60 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { getQuestionReading } from '../api/questionReadingApi';
+import { QuestionReading } from '../Types/tarotReading';
+import QuestionReadingDisplay from '../Components/QuestionReadingDisplay';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faWandSparkles } from '@fortawesome/free-solid-svg-icons';
+import {
+  Container,
+  TryButton,
+  AnimatedIcon
+} from './styles/SharePage.styles';
+import LoadingSpinner from '../Components/LoadingSpinner';
+
+export default function SharePage() {
+  const { readingId } = useParams();
+  const navigate = useNavigate();
+  const [reading, setReading] = useState<QuestionReading | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchReading = async () => {
+      try {
+        if (!readingId) throw new Error('Reading ID is required');
+        const data = await getQuestionReading(readingId);
+        setReading(data);
+      } catch (error) {
+        console.error('결과 조회 실패:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchReading();
+  }, [readingId]);
+
+  if (isLoading) return <LoadingSpinner />;
+  if (!reading) return <p>결과를 찾을 수 없습니다.</p>;
+
+  return (
+    <Container>
+      <QuestionReadingDisplay reading={reading} />
+      <TryButton onClick={() => navigate('/')}>
+        <AnimatedIcon
+          animate={{
+            rotate: [-10, 10, -10],
+          }}
+          transition={{
+            duration: 1.5,
+            repeat: Infinity,
+            ease: "easeInOut"
+          }}
+        >
+          <FontAwesomeIcon icon={faWandSparkles} />
+        </AnimatedIcon>
+        MOONSTRUCK 사용해보기
+      </TryButton>
+    </Container>
+  );
+} 

--- a/src/Pages/styles/ResultPage.styles.ts
+++ b/src/Pages/styles/ResultPage.styles.ts
@@ -1,33 +1,11 @@
 import styled from 'styled-components';
+import { Section, Title } from '../../Components/styles/ReadingDisplay.styles';
 
 export const Container = styled.div`
   padding: 20px;
   max-width: 800px;
   margin: 0 auto;
 `;
-
-export const Section = styled.div`
-  margin-bottom: 40px;
-`;
-
-export const Title = styled.h2`
-  color: #333;
-  margin-bottom: 20px;
-`;
-
-export const CardsContainer = styled.div`
-  display: flex;
-  gap: 20px;
-  flex-wrap: wrap;
-  justify-content: center;
-  margin: 20px 0;
-`;
-
-export const Text = styled.p`
-  white-space: pre-wrap;
-  line-height: 1.6;
-`; 
-
 
 export const HomeButton = styled.button`
   margin-top: 2rem;

--- a/src/Pages/styles/SharePage.styles.ts
+++ b/src/Pages/styles/SharePage.styles.ts
@@ -1,0 +1,39 @@
+import styled from 'styled-components';
+import { motion } from 'motion/react';
+
+export const Container = styled.div`
+  padding: 20px;
+  max-width: 800px;
+  margin: 0 auto;
+`;
+
+export const AnimatedIcon = styled(motion.span)`
+  display: inline-block;
+  margin-right: 8px;
+`;
+
+export const TryButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  width: 100%;
+  margin-top: 2rem;
+  padding: 1rem 2rem;
+  background-color: #6c5ce7;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background-color: #5f3dc4;
+    transform: translateY(-2px);
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+`; 


### PR DESCRIPTION
- result 페이지를 그대로 공유하는 기존의 방식은 사용자 이외의 조회자가 '공유하기' 및 '홈으로 돌아가기' 버튼을 보게 되어있음
- 공유용 페이지인 /share를 만들어 'MOONSTRUCK 사용해보기' 버튼을 노출함
- 추가적으로, **이미 클라이언트에서 갖고 있는 정보 (사용자 입력, 뽑힌 카드, 해석 결과)를 굳이 DB에서 가져와서 불필요한 지연이 발생**하고 있으므로,
  - 기존의 방식대로 정보를 /draw에서 넘겨주되
  - 상태로 넘겨받은 정보가 없으면 파라미터의 :readingId로 db를 조회하도록 /result 페이지의 로직을 수정함
 