### PR TITLE
hotfix: DB에 cards가 제대로 저장되지 않는 문제 수정

### DIFF
--- a/src/Components/SpreadDisplay.tsx
+++ b/src/Components/SpreadDisplay.tsx
@@ -47,7 +47,7 @@ export default function SpreadDisplay({
     } else {
       setDelayedVisibleCount(visibleCardCount);
     }
-  }, [visibleCardCount]);
+  }, [visibleCardCount, delayedVisibleCount]);
 
   const handleCardReveal = () => {
     const newCount = revealedCount + 1;

--- a/src/Pages/DrawPage.tsx
+++ b/src/Pages/DrawPage.tsx
@@ -77,11 +77,10 @@ export default function DrawPage() {
             spreadType
           });
           const interpretation = fetchedApiResponse.content?.[0]?.text || '';
-          
           // 2. DB에 저장
           const response = await saveQuestionReading({
             question: userInput,
-            cards: drawnCards,
+            cards: drawnCardsResult,
             interpretation,
             spreadType
           });


### PR DESCRIPTION
- DB에 결과 저장 요청을 보낼 때, drawnCards상태를 set함수로 업데이트 한 뒤 이를 결과 저장 요청 함수의 파라미터에 넣어 호출하고 있었음.
- setState의 비동기적 작동 방식 때문에 drawnCards가 업데이트되지 않은 상태 (초기값, 빈 배열)로 전송되고 있었음
- 상태 대신 변수를 직접 사용하도록 하여 해결함