### PR TITLE
refactor: 스프레드 디스플레이 로딩 로직 조건화, 스프레드 테스트 페이지 조정, '홈으로 돌아가기' 히스토리 오염 해결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,7 +70,7 @@ function App() {
   return (
     <RecoilRoot>
       <GlobalStyle />
-      <AuthProvider>
+      {/* <AuthProvider> */}
         <AppContainerContext.Provider value={appContainer}>
           <AppContainer ref={containerRef}>
             <Router>
@@ -100,7 +100,7 @@ function App() {
             </Router>
           </AppContainer>
         </AppContainerContext.Provider>
-      </AuthProvider>
+      {/* </AuthProvider> */}
     </RecoilRoot>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import SpreadTestPage from './Pages/SpreadTestPage';
 import DrawTestPage from './Pages/DrawTestPage';
 import DeckTestPage from './Pages/DeckTestPage';
 import SharePage from './Pages/SharePage';
+import StaticSpreadTestPage from './Pages/StaticSpreadTestPage';
 
 const AppContainer = styled.div`
   max-width: 480px;
@@ -87,6 +88,7 @@ function App() {
                 <Route path="/result/:readingId" element={<ResultPage />} />
                 <Route path="/login/:platform" element={<LoginPage />} />
                 <Route path="/spread-test" element={<SpreadTestPage />} />
+                <Route path="/static-spread-test" element={<StaticSpreadTestPage />} />
                 <Route path="/draw-test" element={<DrawTestPage />} />
                 <Route path="/deck-test" element={<DeckTestPage />} />
                 <Route path="/share/:readingId" element={<SharePage />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import ResultPage from './Pages/ResultPage';
 import DrawPage from './Pages/DrawPage';
 import LoginPage from './Pages/LoginPage';
 import { RecoilRoot } from 'recoil';
-import AuthProvider from './utils/AuthProvider';
+// import AuthProvider from './utils/AuthProvider';
 import { createGlobalStyle } from 'styled-components';
 import React, { useRef, useEffect, useState } from 'react';
 import SpreadTestPage from './Pages/SpreadTestPage';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,7 +78,11 @@ function App() {
                 <Route 
                   path="/" 
                   element={
-                    hasVisited ? <Navigate to="/home" /> : <Navigate to="/landing" />
+                    hasVisited ? (
+                      <Navigate to="/home" replace={true} />
+                    ) : (
+                      <Navigate to="/landing" replace={true} />
+                    )
                   } 
                 />
                 <Route path="/landing" element={<LandingPage />} />

--- a/src/Components/QuestionReadingDisplay.tsx
+++ b/src/Components/QuestionReadingDisplay.tsx
@@ -25,6 +25,7 @@ export default function QuestionReadingDisplay({ reading }: QuestionReadingDispl
           spreadType={reading.spreadType}
           revealed={true}
           visibleCardCount={reading.cards.length}
+          needsLoading={true}
         />
       </Section>
 

--- a/src/Components/styles/SpreadDisplay.styles.ts
+++ b/src/Components/styles/SpreadDisplay.styles.ts
@@ -1,0 +1,25 @@
+import styled from "styled-components";
+
+export const SpreadContainer = styled.div`
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+`;
+
+export const LoaderContainer = styled.div`
+  width: 100%;
+  height: 300px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const ErrorMessage = styled.div`
+  color: #ff6b6b;
+  text-align: center;
+  font-size: 1.1rem;
+`;

--- a/src/Pages/DrawPage.tsx
+++ b/src/Pages/DrawPage.tsx
@@ -178,6 +178,7 @@ export default function DrawPage() {
               revealed={cardsRevealed}
               onAllCardsRevealed={handleAllCardsRevealed}
               visibleCardCount={selectedCardIndices.length}
+              needsLoading={false}
             />
             <FlavorText $visible={showFlavorText}>
               이제 타로가 당신의 운명을 보여줄 것입니다...

--- a/src/Pages/SharePage.tsx
+++ b/src/Pages/SharePage.tsx
@@ -53,7 +53,7 @@ export default function SharePage() {
         >
           <FontAwesomeIcon icon={faWandSparkles} />
         </AnimatedIcon>
-        MOONSTRUCK 사용해보기
+        나도 타로점 쳐보기
       </TryButton>
     </Container>
   );

--- a/src/Pages/SpreadTestPage.tsx
+++ b/src/Pages/SpreadTestPage.tsx
@@ -63,6 +63,7 @@ export default function SpreadTestPage() {
           spreadType="SINGLE"
           revealed={REVEALED} 
           visibleCardCount={1}
+          needsLoading={true}
         />
       </SpreadSection>
 
@@ -71,8 +72,9 @@ export default function SpreadTestPage() {
         <SpreadDisplay 
           cards={spreads.triple} 
           spreadType="TRIPLE_CHOICE"
-          revealed={REVEALED} 
+          revealed={false} 
           visibleCardCount={3}
+          needsLoading={false}
         />
       </SpreadSection>
 
@@ -83,6 +85,7 @@ export default function SpreadTestPage() {
           spreadType="FIVE_CARD_CROSS"
           revealed={REVEALED}
           visibleCardCount={5}
+          needsLoading={false}
         />
       </SpreadSection>
 
@@ -93,6 +96,7 @@ export default function SpreadTestPage() {
           spreadType="CELTIC_CROSS"
           revealed={REVEALED}
           visibleCardCount={10}
+          needsLoading={true}
         />
       </SpreadSection>
     </TestPageContainer>

--- a/src/Pages/StaticSpreadTestPage.tsx
+++ b/src/Pages/StaticSpreadTestPage.tsx
@@ -1,0 +1,121 @@
+import { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import SpreadDisplay from '../Components/SpreadDisplay';
+import { drawRandomCards } from '../utils/drawRandomCards';
+import LoadingSpinner from '../Components/LoadingSpinner';
+import { DrawnTarotCard } from '../Types/tarotCard';
+
+const TestPageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 20px;
+`;
+
+const SpreadSection = styled.div`
+  width: 100%;
+  border: 1px solid #ddd;
+  padding: 20px;
+  border-radius: 8px;
+
+  h2 {
+    margin-bottom: 16px;
+  }
+`;
+
+const Button = styled.button`
+  padding: 8px 16px;
+  margin-bottom: 16px;
+  border: none;
+  border-radius: 4px;
+  background-color: #6b4e71;
+  color: white;
+  cursor: pointer;
+`;
+
+// 레이아웃 테스트용 - 항상 앞면
+const INITIAL_REVEALED = true;
+const NEEDS_LOADING = true;  // 이미지 로딩 테스트를 위해
+
+export default function StaticSpreadTestPage() {
+  const [isLoading, setIsLoading] = useState(true);
+  const [spreads, setSpreads] = useState<{
+    single: DrawnTarotCard[];
+    triple: DrawnTarotCard[];
+    five: DrawnTarotCard[];
+    ten: DrawnTarotCard[];
+  }>({
+    single: [],
+    triple: [],
+    five: [],
+    ten: []
+  });
+
+  const drawNewCards = () => {
+    setSpreads({
+      single: drawRandomCards(1),
+      triple: drawRandomCards(3),
+      five: drawRandomCards(5),
+      ten: drawRandomCards(10)
+    });
+  };
+
+  useEffect(() => {
+    drawNewCards();
+    setIsLoading(false);
+  }, []);
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  return (
+    <TestPageContainer>
+      <Button onClick={drawNewCards}>새로운 카드 뽑기</Button>
+
+      <SpreadSection>
+        <h2>Single Spread</h2>
+        <SpreadDisplay 
+          cards={spreads.single} 
+          spreadType="SINGLE"
+          revealed={INITIAL_REVEALED}
+          visibleCardCount={spreads.single.length}
+          needsLoading={NEEDS_LOADING}
+        />
+      </SpreadSection>
+
+      <SpreadSection>
+        <h2>Triple Spread</h2>
+        <SpreadDisplay 
+          cards={spreads.triple} 
+          spreadType="TRIPLE_CHOICE"
+          revealed={INITIAL_REVEALED}
+          visibleCardCount={spreads.triple.length}
+          needsLoading={NEEDS_LOADING}
+        />
+      </SpreadSection>
+
+      <SpreadSection>
+        <h2>Five Card Cross</h2>
+        <SpreadDisplay 
+          cards={spreads.five} 
+          spreadType="FIVE_CARD_CROSS"
+          revealed={INITIAL_REVEALED}
+          visibleCardCount={spreads.five.length}
+          needsLoading={NEEDS_LOADING}
+        />
+      </SpreadSection>
+
+      <SpreadSection>
+        <h2>Celtic Cross</h2>
+        <SpreadDisplay 
+          cards={spreads.ten} 
+          spreadType="CELTIC_CROSS"
+          revealed={INITIAL_REVEALED}
+          visibleCardCount={spreads.ten.length}
+          needsLoading={NEEDS_LOADING}
+        />
+      </SpreadSection>
+    </TestPageContainer>
+  );
+} 

--- a/src/utils/hooks/useCardImages.ts
+++ b/src/utils/hooks/useCardImages.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect } from 'react';
+import { DrawnTarotCard } from '../../Types/tarotCard';
+import { getCardImageUrl } from '../getCardImageUrl';
+
+interface UseCardImagesResult {
+  cardImages: Map<number, string>;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+export function useCardImages(
+  cards: DrawnTarotCard[], 
+  waitForLoad = false  // true면 이미지가 실제로 로드될 때까지 기다림
+): UseCardImagesResult {
+  const [cardImages, setCardImages] = useState<Map<number, string>>(new Map());
+  const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
+
+  useEffect(() => {
+    const loadImages = async () => {
+      setIsLoading(true);
+      setIsError(false);
+      try {
+        // URL 가져오기
+        const imagePromises = cards.map(async card => {
+          const url = await getCardImageUrl(card.id);
+          return [card.id, url] as const;
+        });
+        const loadedUrls = await Promise.all(imagePromises);
+        setCardImages(new Map(loadedUrls));
+
+        if (waitForLoad) {
+          // 실제 이미지 로드 대기
+          const imageElements = loadedUrls.map(([, url]) => {
+            return new Promise((resolve, reject) => {
+              const img = new Image();
+              img.onload = () => img.complete && img.naturalWidth > 0 ? resolve(url) : reject();
+              img.onerror = reject;
+              img.src = url;
+            });
+          });
+          await Promise.all(imageElements);
+        }
+
+        setIsLoading(false);
+      } catch (error) {
+        console.error('Failed to load card images:', error);
+        setIsError(true);
+        setIsLoading(false);
+      }
+    };
+
+    loadImages();
+  }, [cards, waitForLoad]);
+
+  return { cardImages, isLoading, isError };
+} 


### PR DESCRIPTION
- 스프레드 디스플레이의 로딩 로직(이미지가 모두 로드될때까지 스프레드 표시 지연, 로딩스피너 표시)을 needsLoading 프롭으로 조건부로 활성화하도록 수정
- 스프레드 디스플레이의 이미지 불러오기 로직(로딩될 때까지 기다리기와 즉시 불러오기를 포함한)을 useCardImages로 분리
- 이미지 불러오기 오류 발생 시 예외처리 UI 추가
- 
- 스프레드 테스트 페이지를 2개로 분리: spread-test, static-spread-test
  - 카드를 '뽑는' 로직을 포함한 페이지: spread-test
  - 카드는 이미 뽑혀있고, 스프레드가 표시되는 로직만 테스트할 수 있는 페이지: static-spread-test
  - DeckTestPage,DrawTestPage와 함께, 실제 서비스 시에는 삭제할 것
- /result 페이지의 '홈으로 돌아가기'버튼으로 홈 페이지로 돌아간 후, 뒤로가기를 누르면 home=>home=>home=>draw로 이동되는 히스토리 오염 현상의 해결
  - App.tsx의 route설정에서 hasVisited변수에 따라 /landing 혹은 /home으로 이동하는 로직 때문에, navigate to='/'로 되어있는 '홈으로 돌아가기'버튼이 '/'=>'/home'으로 이동시키고, 이후에도 뒤로가기를 누르면 '/'=>'/home'으로 이동하기 때문에 히스토리가 오염되는 것으로 판단, route설정에서 '/landing' 혹은 '/home'으로 이동할 때 replace=true 문을 추가하여 오염을 방지함
- TryButton의 문구를 '나도 MOONSTRUCK 사용해보기' => '나도 타로점 쳐보기'로 수정