### PR TITLE
feat: 서버리스의 API 응답 구조 변경에 따른 수정사항 적용

### DIFF
--- a/src/Pages/DrawPage.tsx
+++ b/src/Pages/DrawPage.tsx
@@ -79,6 +79,7 @@ export default function DrawPage() {
             spreadType
           });
           const interpretation = fetchedApiResponse.content?.[0]?.text || '';
+          console.log(`사용된 모델: ${fetchedApiResponse.model}`);
           // 2. DB에 저장
           const response = await saveQuestionReading({
             question: userInput,

--- a/src/Types/apiResponse.ts
+++ b/src/Types/apiResponse.ts
@@ -1,0 +1,24 @@
+export interface AIResponse {
+  content: Array<{ text: string }>;
+  model: string;
+}
+
+interface VertexError {
+  message: string;
+  status?: number;
+  details?: unknown;
+}
+
+interface GeminiError {
+  message: string;
+  status?: number;
+  details?: unknown;
+}
+
+// 나중에 필요할 수 있는 다른 API 응답 타입들도 여기에 추가
+export interface ErrorResponse {
+  error: string;
+  code: string;
+  vertexError?: VertexError;
+  geminiError?: GeminiError;
+} 

--- a/src/api/callTarotReadingApi.ts
+++ b/src/api/callTarotReadingApi.ts
@@ -1,6 +1,7 @@
 import type { DrawnTarotCard } from '../Types/tarotCard';
 import type { SpreadType } from '../Types/spread';
 import { SPREAD_INFO } from '../Types/spread';
+import type { AIResponse } from '../Types/apiResponse';
 
 interface TarotReadingRequest {
   userInput: string;
@@ -22,7 +23,7 @@ export async function callTarotReadingAPI({
   userInput, 
   cards, 
   spreadType 
-}: TarotReadingRequest) {
+}: TarotReadingRequest): Promise<AIResponse> {
   try {
     const response = await fetch(
       `${import.meta.env.VITE_FIREBASE_FUNCTIONS_API_URL}/tarot-reading`,
@@ -40,7 +41,7 @@ export async function callTarotReadingAPI({
     );
 
     if (!response.ok) {
-      throw new ApiError('API request failed', response.status);
+      throw new ApiError('타로 리딩 요청에 실패했습니다.', response.status);
     }
 
     return response.json();


### PR DESCRIPTION
- 서버리스에서 tarot-reading 요청에 응답을 보낼 때 {response: [...], model: string} 형태로 보내도록 수정함에 따라, 응답 형태를 타입으로 정의함
- DrawPage에서, 받아온 응답에서 해석 결과를 뽑아내는 부분(`const interpretation = fetchedApiResponse.content?.[0]?.text || '';`)은 두 가지 모델(Google Gemini, Anthropic Claude)에 모두 대응 가능한 형태로 되어 있어 별도의 처리는 불필요해보임.
- 받아온 모델 정보를 콘솔에 로깅해주는 부분만 간단하게 추가함