### PR TITLE
feat: 제목/내용 필드를 UI에 적용

### DIFF
--- a/src/Components/QuestionReadingDisplay.tsx
+++ b/src/Components/QuestionReadingDisplay.tsx
@@ -3,14 +3,35 @@ import {
   Section,
   Title,
   Text,
+  ModelInfo
 } from './styles/ReadingDisplay.styles';
 import SpreadDisplay from './SpreadDisplay';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faRobot } from '@fortawesome/free-solid-svg-icons';
+
+// 타입 정의 추가
+interface InterpretationObject {
+  content: string;
+  title: string;
+  model: string;
+}
 
 interface QuestionReadingDisplayProps {
   reading: QuestionReading;
 }
 
 export default function QuestionReadingDisplay({ reading }: QuestionReadingDisplayProps) {
+  // 타입 체크 및 단언
+  const isInterpretationObject = 
+    typeof reading.interpretation === 'object' && 
+    reading.interpretation !== null &&
+    'content' in reading.interpretation;
+  
+  // 객체 형태의 interpretation을 위한 변수
+  const interpretationObj = isInterpretationObject 
+    ? (reading.interpretation as InterpretationObject) 
+    : null;
+
   return (
     <>
       <Section>
@@ -30,8 +51,21 @@ export default function QuestionReadingDisplay({ reading }: QuestionReadingDispl
       </Section>
 
       <Section>
-        <Title>타로 해석</Title>
-        <Text>{reading.interpretation}</Text>
+        {isInterpretationObject && interpretationObj && (
+          <>
+            <Title>{interpretationObj.title}</Title>
+            <Text>{interpretationObj.content}</Text>
+            <ModelInfo>
+              <FontAwesomeIcon icon={faRobot} /> {interpretationObj.model}
+            </ModelInfo>
+          </>
+        )}
+        {!isInterpretationObject && (
+          <>
+            <Title>타로 해석</Title>
+            <Text>{reading.interpretation as string}</Text>
+          </>
+        )}
       </Section>
     </>
   );

--- a/src/Components/styles/ReadingDisplay.styles.ts
+++ b/src/Components/styles/ReadingDisplay.styles.ts
@@ -20,4 +20,13 @@ export const CardsContainer = styled.div`
   flex-wrap: wrap;
   justify-content: center;
   margin: 20px 0;
+`;
+
+export const ModelInfo = styled.div`
+  font-size: 0.8rem;
+  color: #666;
+  margin-top: 16px;
+  margin-right: 8px;
+  text-align: right;
+  font-style: italic;
 `; 

--- a/src/Pages/DrawPage.tsx
+++ b/src/Pages/DrawPage.tsx
@@ -50,7 +50,7 @@ export default function DrawPage() {
   const [currentPhase, setCurrentPhase] = useState<DrawPhase>('shuffle');
   const [drawnCards, setDrawnCards] = useState<DrawnTarotCard[]>([]);
   const [selectedCardIndices, setSelectedCardIndices] = useState<number[]>([]);
-  const [apiResponse, setApiResponse] = useState<string | null>(null);
+  const [apiResponse, setApiResponse] = useState<{content: string; title: string; model: string} | null>(null);
   const [showFlavorText, setShowFlavorText] = useState(false);
   const [readyToNavigate, setReadyToNavigate] = useState(false);
   const hasFetched = useRef(false);
@@ -78,16 +78,29 @@ export default function DrawPage() {
             cards: drawnCardsResult,
             spreadType
           });
-          const interpretation = fetchedApiResponse.content?.[0]?.text || '';
+          
+          // 새로운 응답 형식 처리
           console.log(`사용된 모델: ${fetchedApiResponse.model}`);
+          
           // 2. DB에 저장
           const response = await saveQuestionReading({
             question: userInput,
             cards: drawnCardsResult,
-            interpretation,
+            interpretation: {
+              content: fetchedApiResponse.content,
+              title: fetchedApiResponse.title,
+              model: fetchedApiResponse.model
+            },
             spreadType
           });
-          setApiResponse(interpretation);
+          
+          // 전체 응답 객체 저장
+          setApiResponse({
+            content: fetchedApiResponse.content,
+            title: fetchedApiResponse.title,
+            model: fetchedApiResponse.model
+          });
+          
           setReadingId(response);
         } catch (err) {
           setError({

--- a/src/Types/apiResponse.ts
+++ b/src/Types/apiResponse.ts
@@ -1,24 +1,26 @@
 export interface AIResponse {
-  content: Array<{ text: string }>;
-  model: string;
-}
-
-interface VertexError {
-  message: string;
-  status?: number;
-  details?: unknown;
-}
-
-interface GeminiError {
-  message: string;
-  status?: number;
-  details?: unknown;
-}
-
-// 나중에 필요할 수 있는 다른 API 응답 타입들도 여기에 추가
-export interface ErrorResponse {
-  error: string;
-  code: string;
-  vertexError?: VertexError;
-  geminiError?: GeminiError;
-} 
+    content: string;
+    title: string;
+    model: string;
+    rawResponse?: string;
+  }
+  
+  interface VertexError {
+    message: string;
+    status?: number;
+    details?: unknown;
+  }
+  
+  interface GeminiError {
+    message: string;
+    status?: number;
+    details?: unknown;
+  }
+  
+  // 나중에 필요할 수 있는 다른 API 응답 타입들도 여기에 추가
+  export interface ErrorResponse {
+    error: string;
+    code: string;
+    vertexError?: VertexError;
+    geminiError?: GeminiError;
+  } 

--- a/src/Types/tarotReading.ts
+++ b/src/Types/tarotReading.ts
@@ -1,11 +1,18 @@
 import { DrawnTarotCard } from './tarotCard';
 import { SpreadType } from './spread';
 
+// 해석 타입 정의
+export type Interpretation = string | {
+  content: string;
+  title: string;
+  model: string;
+};
+
 // 공통 인터페이스
 export interface BaseReading {
   id: string;
   cards: DrawnTarotCard[];
-  interpretation: string;
+  interpretation: Interpretation;
   createdAt: string;
 }
 
@@ -14,6 +21,6 @@ export interface QuestionReading {
   id?: string;
   question: string;
   cards: DrawnTarotCard[];
-  interpretation: string;
+  interpretation: Interpretation;
   spreadType: SpreadType;
 } 

--- a/src/api/questionReadingApi.ts
+++ b/src/api/questionReadingApi.ts
@@ -1,17 +1,19 @@
-import { DrawnTarotCard } from "../Types/tarotCard";
-import { SpreadType } from "../Types/spread";
+import { QuestionReading } from '../Types/tarotReading';
+import { SpreadType } from '../Types/spread';
+import { DrawnTarotCard } from '../Types/tarotCard';
 
-export const saveQuestionReading = async ({
-  question,
-  cards,
-  interpretation,
-  spreadType,
-}: {
+interface SaveQuestionReadingParams {
   question: string;
   cards: DrawnTarotCard[];
-  interpretation: string;
+  interpretation: {
+    content: string;
+    title: string;
+    model: string;
+  };
   spreadType: SpreadType;
-}) => {
+}
+
+export async function saveQuestionReading(params: SaveQuestionReadingParams): Promise<string> {
   try {
     const response = await fetch(
       `${import.meta.env.VITE_FIREBASE_FUNCTIONS_API_URL}/question-reading/save`,
@@ -20,12 +22,13 @@ export const saveQuestionReading = async ({
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ question, cards, interpretation, spreadType })
+        body: JSON.stringify(params),
       }
     );
 
     if (!response.ok) {
-      throw new Error('Failed to save reading');
+      const errorData = await response.json();
+      throw new Error(errorData.error || '타로 리딩 저장에 실패했습니다.');
     }
 
     const { readingId } = await response.json();
@@ -36,17 +39,18 @@ export const saveQuestionReading = async ({
   }
 }
 
-export async function getQuestionReading(readingId: string) {
+export async function getQuestionReading(readingId: string): Promise<QuestionReading> {
   try {
     const response = await fetch(
       `${import.meta.env.VITE_FIREBASE_FUNCTIONS_API_URL}/question-reading/get/${readingId}`
     );
 
     if (!response.ok) {
-      throw new Error('Reading not found');
+      const errorData = await response.json();
+      throw new Error(errorData.error || '타로 리딩을 불러오는데 실패했습니다.');
     }
 
-    return response.json();
+    return await response.json();
   } catch (error) {
     console.error('Get Reading Error:', error);
     throw error;


### PR DESCRIPTION
- 백엔드에서 LLM 출력 결과를 title과 content로 분리하여 내려주도록 변경됨
- 이에 따라 답변 타입이나 api 접근 시 파라미터 등을 변경된 스펙과 동일하게 수정
- 또한, 결과 페이지와 공유 페이지에서 사용하는 QuestionReadingDisplay에서 title과 content를 UI상으로 표시하도록 변경
- response가 필요한 형식을 따르지 않았을 경우(interpretation이 객체가 아닌 경우) interpretation을 string으로 표시하도록 예외처리
  - 이건 서버리스에서 rawResponse를 내려주는데 그걸 활용하는 게 더 낫지 않을까? 수정 필요